### PR TITLE
docs(plans): estudio del pack opcional Canvas Extensions (GitHub Copilot app)

### DIFF
--- a/.github/plans/canvas-extensions-catalog.md
+++ b/.github/plans/canvas-extensions-catalog.md
@@ -1,0 +1,95 @@
+# Study (companion) — ALDC methodology canvases + agent-consumption evaluation
+
+**Status:** PROPOSED (exploration). Companion to [`canvas-extensions-pack.md`](./canvas-extensions-pack.md). Nothing shipped.
+**Scope:** (1) design a catalog of canvases oriented to the **ALDC methodology**; (2) evaluate whether they can be **consumed by agents**.
+**Pilot:** the Conductor canvas (study §4) is prototyped in [`canvas-extensions-pack-prototype/`](./canvas-extensions-pack-prototype/); this doc generalizes it to the whole methodology and answers the agent-consumption question.
+
+---
+
+## 1. Design principle — canvases follow the methodology, not the tool
+
+ALDC's methodology is a **spec-driven TDD pipeline with HITL gates**. Every stage already emits a structured markdown artifact under `.github/plans/`. A *methodology canvas* is a **view/controller over one such artifact**.
+
+> **Design rule:** one canvas per methodology artifact; the artifact is the source of truth; the canvas never holds private state. This is what makes the catalog coherent *and* agent-consumable (§3).
+
+## 2. The canvas catalog (mapped to ALDC stages)
+
+| # | Canvas | Stage / owner | Backing artifact (source of truth) | Reads | HITL writes |
+|---|--------|---------------|-----------------------------------|-------|-------------|
+| **C1** | Spec Studio | `/al-spec.create` | `{req}.spec.md` | sections + acceptance-criteria table | approve spec · edit AC |
+| **C2** | Architecture Board | `al-architect` | `{req}.architecture.md` | 14 sections · `TD-xx` decisions · risks | approve · flag a decision to revisit |
+| **C3** | Test-Plan Checklist | skill-testing | `{req}.test-plan.md` | `AC-xx` pass/fail | toggle AC · link to test codeunit |
+| **C4** ⭐ | **Conductor Pipeline** (prototyped) | `al-conductor` | `{req}-phase-N-complete.md` + gates | RED·GREEN·REFACTOR · quality gates | approve / redirect a gate |
+| **C5** | Review / Audit Board | `al-triage` · `dredd` · review-subagent | findings + `*-bcquality-*.json` | findings by severity + citations | accept / dismiss / assign to `al-developer` |
+| **C6** | Estimation Dashboard | `al-presales` | estimation artifact (PERT / SWOT) | estimate ranges · risk matrix | adjust assumptions → re-estimate |
+| **C7** | Release Checklist | `/al-build` · `/al-pr-prepare` | build / PR-prep output + `memory.md` | pre/post-deploy checks · PR readiness | gate the release |
+| **C8** | Memory Lens (cross-cutting) | global | `.github/plans/memory.md` | cross-session decisions | pin / append a decision |
+
+**Notes.** C4 is the cheapest first build (already prototyped). C1–C3 reuse the same parse-markdown-headers approach as C4 against existing templates. C5 is the highest-value *new* surface (turns `dredd`/`al-triage` verdicts into a triage board). C8 is a side-panel rendered alongside any other canvas, not a standalone.
+
+## 3. Agent-consumption evaluation — *can agents consume these?*
+
+There are **two distinct consumption paths**, and the answer differs by path.
+
+### 3A. In-host — the Copilot-app agent ↔ canvas capabilities (native, supported ✅)
+
+Per GitHub's docs, "both people and agents interact with that same shared state through UI actions and **agent-callable capabilities**," and you can "ask the agent to **call capabilities** exposed by the canvas to update data or take actions." So inside the Copilot app the agent consumes the canvas **directly** by invoking its capabilities — the `capabilities` object the prototype exports. The companion `agent-consume.mjs` (§5) demonstrates exactly this call pattern.
+
+### 3B. Cross-host — ALDC's own agents ↔ shared markdown (indirect, via the artifact)
+
+ALDC's agents (`al-conductor`, `al-developer`, subagents, `dredd`) run in **Claude Code / Copilot Chat**, **not** in the Copilot app, so they **cannot call the canvas object directly**. They interoperate through the **shared `.github/plans/` markdown**, which is already ALDC's source of truth:
+
+```
+ALDC agent  ──writes──▶  {req}-phase-N-complete.md  ──renders──▶  Canvas (Copilot app)
+                                   ▲                                     │
+   next agent run ──reads──────────┴──────────writes-back (HITL)────────┘  human steers
+```
+
+→ **Indirect but robust**: the markdown **templates are the interop schema**; no shared runtime is required. This works precisely because ALDC already enforces *spec-as-truth* + HITL on these files.
+
+### 3C. What "agent-consumable" requires
+
+| Requirement | Why it matters | Prototype status |
+|---|---|---|
+| Stable artifact schema | canvas + agents must parse the same headers | uses existing templates' headers |
+| Versioned capability contract | in-host agents bind to capability names/params | thin `capabilities` object |
+| Append-only / idempotent writes | human + agent edits must not clobber | append-only; git is the merge surface |
+| No hidden canvas state | agents must see what the human did | source-of-truth invariant |
+
+### 3D. Risks specific to agent-consumption
+
+| Risk | Mitigation |
+|---|---|
+| Template drift breaks the canvas parser | pin parsing to template version; add a template-contract test |
+| Capability API preview/unstable | keep logic in **pure functions over markdown** + a thin host binding (the prototype's structure) |
+| Cross-host race (human vs. agent edit) | append-only writes; reconcile via git |
+| Canvas silently overwrites agent-authored status | canvas **records** human intent, never rewrites the canonical status line (TD-01) |
+
+### TD-01: approve = *record*, not *overwrite*
+
+- **Problem:** should `approveGate` flip the gate by rewriting `**Review Status:**`?
+- **Decision:** no — it **appends** a human-approval record; the canonical status line stays agent-authored.
+- **Rationale:** prevents the canvas from becoming a second source of truth; keeps `al-conductor` the authority on status; reconciliation stays explicit and auditable. (This is why, in the §5 demo, the gate intentionally does **not** auto-flip after `approveGate`.)
+
+## 4. Verdict
+
+**Yes — methodology canvases are agent-consumable on both paths:** directly in-host (Copilot agent ↔ capabilities) and indirectly cross-host (ALDC agents ↔ shared markdown). The enabling choice is the one already in the prototype: **pure functions over `.github/plans/` markdown + a thin capability binding**, with the markdown templates as the interop schema.
+
+**Recommended sequencing:** build the **read path** for C1–C4 first (cheap — reuses the Conductor parser), keep all writes append-only, add C5 (audit board) as the first high-value new surface, and **defer in-host capability *registration* until the Canvas API leaves technical preview**.
+
+## 5. Demonstrated
+
+[`canvas-extensions-pack-prototype/agent-consume.mjs`](./canvas-extensions-pack-prototype/agent-consume.mjs) invokes the canvas capabilities **programmatically — the same way an agent does** — proving read + HITL-write consumption against markdown, with no Copilot app:
+
+```bash
+cd .github/plans/canvas-extensions-pack-prototype
+node agent-consume.mjs
+```
+
+---
+
+### References
+
+- Working with canvas extensions — GitHub Docs: `https://docs.github.com/en/copilot/how-tos/github-copilot-app/working-with-canvas-extensions`
+- GitHub Copilot app: the agent-native desktop experience — GitHub Blog: `https://github.blog/news-insights/product-news/github-copilot-app-the-agent-native-desktop-experience/`
+- Canvas Extensions — Awesome GitHub Copilot: `https://awesome-copilot.github.com/extensions/`

--- a/.github/plans/canvas-extensions-catalog.md
+++ b/.github/plans/canvas-extensions-catalog.md
@@ -89,10 +89,17 @@ node agent-consume.mjs
 The read path now generalizes beyond the Conductor: `demo-all.mjs` loads **C1 (Spec Studio)**,
 **C3 (Test-Plan Checklist)** and **C4 (Conductor Pipeline)** over one plan dir, all built on the shared
 `lib.mjs` core — concrete evidence for the §1 design rule and the §3C "stable artifact schema" requirement.
-C2, C5–C8 remain designed-only; **C5 (Review/Audit Board)** is the recommended next new surface.
+
+**C5 (Review/Audit Board)** is prototyped too, bound to the **canonical Dredd Audit-Report JSON**
+(`.github/audits/dredd-audit-*.json`, schema per `agents/dredd.agent.md` Step 4): it renders verdict +
+severity counts + findings (`file:line` + citation), and its HITL triage (accept / dismiss / assign) is
+appended to a **sidecar** `<audit>.triage.json` so Dredd's CI-validated report stays immutable (TD-01).
+That sidecar is the §3B cross-host handoff made concrete: `dredd → JSON → canvas (human triage) →
+sidecar → al-developer`. **Prototyped: C1, C3, C4, C5** · designed-only: C2, C6, C7, C8.
 
 ```bash
-node demo-all.mjs
+node demo-all.mjs      # C1 + C3 + C4 (per-requirement canvases)
+node demo-audit.mjs    # C5 Review/Audit Board (read board + HITL triage write)
 ```
 
 ---

--- a/.github/plans/canvas-extensions-catalog.md
+++ b/.github/plans/canvas-extensions-catalog.md
@@ -86,6 +86,15 @@ cd .github/plans/canvas-extensions-pack-prototype
 node agent-consume.mjs
 ```
 
+The read path now generalizes beyond the Conductor: `demo-all.mjs` loads **C1 (Spec Studio)**,
+**C3 (Test-Plan Checklist)** and **C4 (Conductor Pipeline)** over one plan dir, all built on the shared
+`lib.mjs` core — concrete evidence for the §1 design rule and the §3C "stable artifact schema" requirement.
+C2, C5–C8 remain designed-only; **C5 (Review/Audit Board)** is the recommended next new surface.
+
+```bash
+node demo-all.mjs
+```
+
 ---
 
 ### References

--- a/.github/plans/canvas-extensions-pack-prototype/README.md
+++ b/.github/plans/canvas-extensions-pack-prototype/README.md
@@ -33,3 +33,24 @@ node extension.mjs fixture sample-req     # or: npm run demo
 
 Prints the derived view model (`run`, `phases`, `gates`) for the bundled `fixture/sample-req/` plan —
 demonstrating P0/P1 of the study's execution plan against real markdown.
+
+## Files
+
+| File | Role |
+|------|------|
+| `lib.mjs` | shared read-only core (markdown parsers) used by every canvas |
+| `extension.mjs` | **C4** Conductor Pipeline canvas + standalone runner |
+| `spec-studio.mjs` | **C1** Spec Studio canvas (read path) |
+| `test-plan.mjs` | **C3** Test-Plan Checklist canvas (read path) |
+| `agent-consume.mjs` | demonstrates agent consumption of capabilities (read + HITL write) |
+| `demo-all.mjs` | loads C1 + C3 + C4 over one plan dir |
+| `fixture/sample-req/` | sample plan the runners read |
+
+## Multi-canvas demo
+
+```bash
+node demo-all.mjs        # prints C1, C3 and C4 view models for fixture/sample-req
+```
+
+Shows the catalog pattern generalizing: three methodology canvases built on the same `lib.mjs`
+core, each a view over its own markdown artifact. See [`../canvas-extensions-catalog.md`](../canvas-extensions-catalog.md).

--- a/.github/plans/canvas-extensions-pack-prototype/README.md
+++ b/.github/plans/canvas-extensions-pack-prototype/README.md
@@ -1,0 +1,35 @@
+# Prototype — al-conductor TDD pipeline canvas
+
+Reference spike for the study [`../canvas-extensions-pack.md`](../canvas-extensions-pack.md) §4. It makes a
+Conductor run **visible and steerable** in the GitHub Copilot app, while keeping the markdown under
+`.github/plans/` as the single source of truth.
+
+> **This is NOT shipped.** It is not declared in `aldc.yaml`, touches no Core agent/workflow/template,
+> and modifies no normative spec — so it cannot affect conformance or CI. It exists only to make the
+> proposal concrete and to de-risk the §6 execution plan. The Copilot-app canvas host API is in
+> **technical preview**; the `host` binding in `extension.mjs` follows the documented *concepts*
+> (agent-callable capabilities + bidirectional state) and must be reconciled with the official surface
+> before anything ships.
+
+## Capabilities (study §4)
+
+| Capability | Direction | Backing artifact |
+|---|---|---|
+| `loadRun` | read | `{req}.spec.md`, `{req}.architecture.md`, `{req}.test-plan.md` |
+| `renderPhases` | read | `{req}-phase-N-complete.md` (parses title + `Review Status`) |
+| `renderGates` | read | derived gate state per phase (`passed` / `blocked` / `pending`) |
+| `approveGate` | **write (HITL)** | appends an approval line to the phase report |
+| `requestRevision` | **write (HITL)** | appends a `NEEDS_REVISION` note to the phase report |
+
+**Source-of-truth invariant:** every write goes back to the git-versioned markdown; the view is always
+re-derived from disk. The canvas never holds private state.
+
+## Try the read path (no Copilot app needed)
+
+```bash
+cd .github/plans/canvas-extensions-pack-prototype
+node extension.mjs fixture sample-req     # or: npm run demo
+```
+
+Prints the derived view model (`run`, `phases`, `gates`) for the bundled `fixture/sample-req/` plan —
+demonstrating P0/P1 of the study's execution plan against real markdown.

--- a/.github/plans/canvas-extensions-pack-prototype/README.md
+++ b/.github/plans/canvas-extensions-pack-prototype/README.md
@@ -38,19 +38,24 @@ demonstrating P0/P1 of the study's execution plan against real markdown.
 
 | File | Role |
 |------|------|
-| `lib.mjs` | shared read-only core (markdown parsers) used by every canvas |
+| `lib.mjs` | shared read-only core (markdown parsers) used by the per-requirement canvases |
 | `extension.mjs` | **C4** Conductor Pipeline canvas + standalone runner |
 | `spec-studio.mjs` | **C1** Spec Studio canvas (read path) |
 | `test-plan.mjs` | **C3** Test-Plan Checklist canvas (read path) |
+| `review-audit.mjs` | **C5** Review/Audit Board (read + HITL triage over the Dredd Audit-Report JSON) |
 | `agent-consume.mjs` | demonstrates agent consumption of capabilities (read + HITL write) |
 | `demo-all.mjs` | loads C1 + C3 + C4 over one plan dir |
-| `fixture/sample-req/` | sample plan the runners read |
+| `demo-audit.mjs` | C5 read board + HITL triage write (sidecar) |
+| `fixture/sample-req/` | sample plan the per-requirement runners read |
+| `fixture/audits/` | sample Dredd Audit-Report JSON the C5 runner reads |
 
 ## Multi-canvas demo
 
 ```bash
 node demo-all.mjs        # prints C1, C3 and C4 view models for fixture/sample-req
+node demo-audit.mjs      # C5 Review/Audit Board: triage board + HITL assign to al-developer (sidecar)
 ```
 
-Shows the catalog pattern generalizing: three methodology canvases built on the same `lib.mjs`
-core, each a view over its own markdown artifact. See [`../canvas-extensions-catalog.md`](../canvas-extensions-catalog.md).
+Shows the catalog pattern generalizing across artifacts: the per-requirement canvases (C1/C3/C4) share
+the `lib.mjs` markdown core, and C5 binds to the canonical Dredd Audit-Report JSON. See
+[`../canvas-extensions-catalog.md`](../canvas-extensions-catalog.md).

--- a/.github/plans/canvas-extensions-pack-prototype/agent-consume.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/agent-consume.mjs
@@ -1,0 +1,43 @@
+// Demonstrates AGENT CONSUMPTION of the canvas capabilities WITHOUT the Copilot app UI.
+//
+// An in-host Copilot agent would call these capabilities the same way (see
+// ../canvas-extensions-catalog.md §3A). Cross-host ALDC agents instead share the same
+// .github/plans/ markdown artifact (§3B). This harness exercises the capability surface
+// directly against a throwaway temp plan dir, so it never touches the committed fixture.
+//
+// Run: node agent-consume.mjs
+
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import createConductorCanvas from './extension.mjs';
+
+// --- arrange: a throwaway plan dir with one phase mid-review ---------------------------------
+const root = await mkdtemp(join(tmpdir(), 'aldc-canvas-'));
+const reqName = 'demo-req';
+await mkdir(join(root, reqName), { recursive: true });
+await writeFile(join(root, reqName, `${reqName}.spec.md`), '# Demo Requirement\n');
+await writeFile(
+  join(root, reqName, `${reqName}-phase-1-complete.md`),
+  '## Phase 1 Complete: RED — failing tests written\n\n**Review Status:** NEEDS_REVISION\n',
+);
+
+const canvas = createConductorCanvas(null, { planDir: root });
+
+// --- act + assert: an agent consuming the capability surface ---------------------------------
+console.log('Capabilities an agent can call:', Object.keys(canvas.capabilities).join(', '));
+
+// 1) READ — agent inspects pipeline gate state
+console.log('\n[read]  renderGates →', JSON.stringify(await canvas.capabilities.renderGates({ reqName })));
+
+// 2) HITL WRITE — agent records a human gate decision back to the markdown (append-only)
+const w = await canvas.capabilities.approveGate({ reqName, phase: 1, approver: 'agent-on-behalf-of-human' });
+console.log('[write] approveGate appended →', JSON.stringify(w.appended));
+
+// 3) RE-DERIVE — view is read straight from markdown; gate stays driven by the canonical
+//    Review Status line (TD-01: approve records intent, it does NOT overwrite agent-authored status).
+console.log('[read]  renderGates →', JSON.stringify(await canvas.capabilities.renderGates({ reqName })),
+  '  ← intentionally still blocked (TD-01)');
+
+const persisted = (await readFile(join(root, reqName, `${reqName}-phase-1-complete.md`), 'utf8')).trim();
+console.log('\nPersisted to the source of truth (last line):\n  ' + persisted.split('\n').at(-1));

--- a/.github/plans/canvas-extensions-pack-prototype/demo-all.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/demo-all.mjs
@@ -1,0 +1,22 @@
+// Loads multiple ALDC methodology canvases over ONE plan dir — proving the catalog pattern
+// generalizes across artifacts on a shared markdown core (read path only):
+//   C1 Spec Studio · C3 Test-Plan Checklist · C4 Conductor Pipeline.
+// Run: node demo-all.mjs [planDir] [reqName]   (defaults: fixture sample-req)
+
+import createConductorCanvas from './extension.mjs';
+import createSpecStudioCanvas from './spec-studio.mjs';
+import createTestPlanCanvas from './test-plan.mjs';
+
+const [planDir = 'fixture', reqName = 'sample-req'] = process.argv.slice(2);
+const opts = { planDir };
+
+const canvases = {
+  'C1 Spec Studio': createSpecStudioCanvas(null, opts),
+  'C3 Test-Plan Checklist': createTestPlanCanvas(null, opts),
+  'C4 Conductor Pipeline': createConductorCanvas(null, opts),
+};
+
+for (const [name, canvas] of Object.entries(canvases)) {
+  console.log(`\n=== ${name} ===`);
+  console.log(JSON.stringify(await canvas.view(reqName), null, 2));
+}

--- a/.github/plans/canvas-extensions-pack-prototype/demo-audit.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/demo-audit.mjs
@@ -1,0 +1,34 @@
+// C5 Review/Audit Board demo — read the triage board from a real Dredd Audit-Report JSON, then
+// exercise the HITL triage write. The write goes to a SIDECAR in a temp dir so the committed
+// fixture (and, in real use, Dredd's CI-validated report) stays immutable (TD-01).
+// Run: node demo-audit.mjs
+
+import { mkdtemp, copyFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import createReviewAuditCanvas from './review-audit.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureAuditsDir = join(here, 'fixture', 'audits');
+const auditName = 'dredd-audit-2026-06-20-0900.json';
+
+// 1) READ — triage board straight from the committed fixture (no mutation)
+const ro = createReviewAuditCanvas(null, { auditsDir: fixtureAuditsDir });
+console.log('Capabilities an agent can call:', Object.keys(ro.capabilities).join(', '));
+const board = await ro.capabilities.renderBoard();
+console.log(`\nVerdict: ${board.verdict}  | counts: ${JSON.stringify(board.counts)}  | BCQuality sha: ${board.bcqualitySha}`);
+for (const f of board.findings) console.log(`  [${f.severity}] ${f.at}  ${f.id}${f.citation ? `  (cite: ${f.citation})` : ''}`);
+
+// 2) HITL WRITE — assign the major finding to al-developer. Sidecar keeps Dredd's report immutable.
+const tmp = await mkdtemp(join(tmpdir(), 'aldc-audit-'));
+await copyFile(join(fixtureAuditsDir, auditName), join(tmp, auditName));
+const rw = createReviewAuditCanvas(null, { auditsDir: tmp });
+const res = await rw.capabilities.triageFinding({
+  findingId: 'performance/al-performance.md#setloadfields',
+  action: 'assign',
+  assignee: 'al-developer',
+  note: 'fix before release',
+});
+console.log(`\n[write] triage decision → ${res.sidecar} (${res.total} decision)`);
+console.log('sidecar the next agent (al-developer) consumes:\n' + (await readFile(join(tmp, res.sidecar), 'utf8')).trim());

--- a/.github/plans/canvas-extensions-pack-prototype/extension.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/extension.mjs
@@ -11,16 +11,14 @@
 // Every capability re-derives its view from those files; writes append to the markdown phase
 // report — the canvas never becomes a second store.
 
-import { readFile, writeFile, readdir, access } from 'node:fs/promises';
+import { readFile, writeFile, readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { exists, readIf } from './lib.mjs';
 
 const PHASE_RE = /^##\s+Phase\s+(\d+)\s+Complete:\s*(.+?)\s*$/m;
 const REVIEW_RE = /^\*\*Review Status:\*\*\s*(.+?)\s*$/m;
 const H1_RE = /^#\s+(.+)$/m;
-
-const exists = async (p) => { try { await access(p); return true; } catch { return false; } };
-const readIf = async (p) => ((await exists(p)) ? readFile(p, 'utf8') : '');
 
 // --- read model (re-derived from disk on every call) ----------------------------------------
 

--- a/.github/plans/canvas-extensions-pack-prototype/extension.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/extension.mjs
@@ -1,0 +1,125 @@
+// ALDC Canvas Extensions — PROTOTYPE (reference spike; NOT shipped, NOT declared in aldc.yaml).
+// Pilot from the study .github/plans/canvas-extensions-pack.md §4:
+//   the al-conductor TDD pipeline canvas for the GitHub Copilot app.
+//
+// Honesty caveat: the Copilot-app canvas host API (capability registration / UI push) is in
+// technical preview and not fully public. The `host` binding below follows the documented
+// *concepts* (agent-callable capabilities + bidirectional shared state) and MUST be reconciled
+// with the official extension.mjs surface before anything ships.
+//
+// Invariant (study §4): the markdown under .github/plans/ is the single source of truth.
+// Every capability re-derives its view from those files; writes append to the markdown phase
+// report — the canvas never becomes a second store.
+
+import { readFile, writeFile, readdir, access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PHASE_RE = /^##\s+Phase\s+(\d+)\s+Complete:\s*(.+?)\s*$/m;
+const REVIEW_RE = /^\*\*Review Status:\*\*\s*(.+?)\s*$/m;
+const H1_RE = /^#\s+(.+)$/m;
+
+const exists = async (p) => { try { await access(p); return true; } catch { return false; } };
+const readIf = async (p) => ((await exists(p)) ? readFile(p, 'utf8') : '');
+
+// --- read model (re-derived from disk on every call) ----------------------------------------
+
+async function loadRun(planDir, reqName) {
+  const base = join(planDir, reqName);
+  const [spec, testPlan, arch] = await Promise.all([
+    readIf(join(base, `${reqName}.spec.md`)),
+    readIf(join(base, `${reqName}.test-plan.md`)),
+    readIf(join(base, `${reqName}.architecture.md`)),
+  ]);
+  return {
+    reqName,
+    title: (spec.match(H1_RE) || [, reqName])[1],
+    hasSpec: !!spec,
+    hasTestPlan: !!testPlan,
+    hasArchitecture: !!arch,
+  };
+}
+
+async function renderPhases(planDir, reqName) {
+  const base = join(planDir, reqName);
+  let entries = [];
+  try { entries = await readdir(base); } catch { /* dir not created yet */ }
+  const re = new RegExp(`^${reqName}-phase-(\\d+)-complete\\.md$`);
+  const phases = [];
+  for (const file of entries) {
+    const m = file.match(re);
+    if (!m) continue;
+    const body = await readFile(join(base, file), 'utf8');
+    const review = (body.match(REVIEW_RE) || [, 'PENDING'])[1];
+    phases.push({
+      n: Number(m[1]),
+      title: (body.match(PHASE_RE) || [, , '(untitled)'])[2],
+      review,
+      gate: gateOf(review),
+      file,
+    });
+  }
+  return phases.sort((a, b) => a.n - b.n);
+}
+
+const gateOf = (review) => {
+  const r = (review || '').toUpperCase();
+  if (r.startsWith('APPROVED')) return 'passed';
+  if (r.includes('NEEDS_REVISION')) return 'blocked';
+  return 'pending';
+};
+
+const renderGates = (phases) => phases.map((p) => ({ phase: p.n, gate: p.gate, detail: p.review }));
+
+// --- write model (HITL; appends to the markdown phase report) --------------------------------
+
+const approveGate = (planDir, reqName, phaseN, approver = 'human') =>
+  appendToPhase(planDir, reqName, phaseN,
+    `\n> **HITL gate APPROVED** by ${approver} at ${new Date().toISOString()}\n`);
+
+const requestRevision = (planDir, reqName, phaseN, note, approver = 'human') =>
+  appendToPhase(planDir, reqName, phaseN,
+    `\n> **HITL gate NEEDS_REVISION** by ${approver} at ${new Date().toISOString()}: ${note}\n`);
+
+async function appendToPhase(planDir, reqName, phaseN, line) {
+  const file = join(planDir, reqName, `${reqName}-phase-${phaseN}-complete.md`);
+  if (!(await exists(file))) throw new Error(`No phase report to write back to: ${file}`);
+  await writeFile(file, (await readFile(file, 'utf8')) + line);
+  return { file, appended: line.trim() };
+}
+
+// --- canvas host binding (concepts only — reconcile with the official preview API) -----------
+
+export default function createConductorCanvas(host, { planDir = '.github/plans' } = {}) {
+  // `capabilities` are what the Copilot agent may call; the human drives the same shared state
+  // through the canvas UI actions the host renders from `view()`.
+  const capabilities = {
+    loadRun: ({ reqName }) => loadRun(planDir, reqName),
+    renderPhases: ({ reqName }) => renderPhases(planDir, reqName),
+    renderGates: async ({ reqName }) => renderGates(await renderPhases(planDir, reqName)),
+    approveGate: ({ reqName, phase, approver }) => approveGate(planDir, reqName, phase, approver),
+    requestRevision: ({ reqName, phase, note, approver }) =>
+      requestRevision(planDir, reqName, phase, note, approver),
+  };
+  // host?.registerCapabilities?.(capabilities); // ← official registration API TBD (preview)
+  return {
+    capabilities,
+    async view(reqName) {
+      const [run, phases] = await Promise.all([
+        loadRun(planDir, reqName),
+        renderPhases(planDir, reqName),
+      ]);
+      return { run, phases, gates: renderGates(phases) };
+    },
+  };
+}
+
+// --- standalone runner: demonstrates the read path with no Copilot app -----------------------
+// Usage: node extension.mjs [planDir] [reqName]   (defaults: fixture sample-req)
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [planDir = 'fixture', reqName = 'sample-req'] = process.argv.slice(2);
+  createConductorCanvas(null, { planDir })
+    .view(reqName)
+    .then((v) => console.log(JSON.stringify(v, null, 2)))
+    .catch((err) => { console.error(err.message); process.exit(1); });
+}

--- a/.github/plans/canvas-extensions-pack-prototype/fixture/audits/dredd-audit-2026-06-20-0900.json
+++ b/.github/plans/canvas-extensions-pack-prototype/fixture/audits/dredd-audit-2026-06-20-0900.json
@@ -1,0 +1,59 @@
+{
+  "skill": { "id": "dredd", "version": 1 },
+  "outcome": "completed",
+  "audit": {
+    "target": "changed-vs-main",
+    "verdict": "FAIL",
+    "gate": "advisory",
+    "bcquality": {
+      "submodule-sha": "f562fba",
+      "outcome": "completed",
+      "skills-run": ["al-performance-review", "al-security-review", "al-style-review"]
+    },
+    "coverage": { "objects-total": 3, "objects-audited": 3 },
+    "notes": "Fixture audit for the C5 Review/Audit Board prototype. Not a real audit."
+  },
+  "summary": {
+    "counts": { "blocker": 0, "major": 1, "minor": 1, "info": 1 },
+    "coverage": { "worklist-size": 12, "items-evaluated": 12 }
+  },
+  "findings": [
+    {
+      "id": "performance/al-performance.md#setloadfields",
+      "source": "bcquality",
+      "domain": "performance",
+      "severity": "major",
+      "message": "Heavy query without SetLoadFields loads all fields on every page render.",
+      "location": { "file": "src/CustomerExt.PageExt.al", "line": 42 },
+      "references": [{ "path": "performance/al-performance.md", "sha": "f562fba" }],
+      "confidence": "high",
+      "fix-hint": "Call SetLoadFields(...) before FindSet()."
+    },
+    {
+      "id": "native:error-without-context",
+      "source": "native",
+      "domain": "error-handling",
+      "severity": "minor",
+      "message": "Error() raised without a descriptive, labelled message hampers diagnostics.",
+      "location": { "file": "src/OrderMgt.Codeunit.al", "line": 88 },
+      "references": [],
+      "native-rule": { "path": "instructions/al-error-handling.instructions.md" },
+      "confidence": "medium",
+      "fix-hint": "Use a labelled error with operation context."
+    },
+    {
+      "id": "agent:naming-abbreviation",
+      "source": "agent",
+      "domain": "style",
+      "severity": "info",
+      "message": "Abbreviated variable 'custNo' could be spelled out for clarity.",
+      "location": { "file": "src/OrderMgt.Codeunit.al", "line": 15 },
+      "references": [],
+      "from-sub-skill": "agent",
+      "confidence": "low",
+      "fix-hint": "Rename to 'customerNo'."
+    }
+  ],
+  "suppressed": [],
+  "sub-results": []
+}

--- a/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req-phase-1-complete.md
+++ b/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req-phase-1-complete.md
@@ -1,0 +1,5 @@
+## Phase 1 Complete: Planning & test scaffold
+
+Fixture phase report so the prototype has a real artifact to parse. Demonstrates the `passed` gate.
+
+**Review Status:** APPROVED

--- a/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req.spec.md
+++ b/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req.spec.md
@@ -1,0 +1,10 @@
+# Sample Requirement — Conductor canvas demo
+
+> Fixture for the prototype standalone runner. **Not** a real ALDC specification — it exists only so
+> `node extension.mjs fixture sample-req` has a plan to read.
+
+## Acceptance criteria
+
+| ID | Criterion |
+|----|-----------|
+| AC-01 | The canvas renders one row per `*-phase-N-complete.md` with its gate state. |

--- a/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req.test-plan.md
+++ b/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req.test-plan.md
@@ -1,0 +1,6 @@
+# Test Plan: Sample Requirement
+
+> Fixture for the prototype standalone runner.
+
+- **AC-01** — Given a plan dir with phase reports, when the canvas loads, then each phase appears with
+  its `Review Status` mapped to a gate (`passed` / `blocked` / `pending`).

--- a/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req.test-plan.md
+++ b/.github/plans/canvas-extensions-pack-prototype/fixture/sample-req/sample-req.test-plan.md
@@ -2,5 +2,4 @@
 
 > Fixture for the prototype standalone runner.
 
-- **AC-01** — Given a plan dir with phase reports, when the canvas loads, then each phase appears with
-  its `Review Status` mapped to a gate (`passed` / `blocked` / `pending`).
+- **AC-01** — Given a plan dir with phase reports, the canvas lists each phase with its gate (passed / blocked / pending).

--- a/.github/plans/canvas-extensions-pack-prototype/lib.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/lib.mjs
@@ -1,0 +1,30 @@
+// Shared read-only core for ALDC methodology canvases (prototype).
+// Pure functions over the .github/plans/ markdown — the "stable artifact schema" the
+// agent-consumption evaluation (../canvas-extensions-catalog.md §3C) depends on. Every canvas
+// (Conductor, Spec Studio, Test-Plan, …) builds its view on top of these helpers, so there is
+// one parser to keep in sync with the templates, not one per canvas.
+
+import { readFile, access } from 'node:fs/promises';
+
+export const exists = async (p) => { try { await access(p); return true; } catch { return false; } };
+export const readIf = async (p) => ((await exists(p)) ? readFile(p, 'utf8') : '');
+
+export const firstHeading = (md) => (md.match(/^#\s+(.+?)\s*$/m) || [, ''])[1];
+export const sectionHeadings = (md) => [...md.matchAll(/^##\s+(.+?)\s*$/gm)].map((m) => m[1]);
+
+// Acceptance criteria from either a table row `| AC-01 | … |` or a bold bullet `- **AC-01** — …`.
+// Returns a de-duplicated, numerically-sorted [{ id, text }].
+export function acceptanceCriteria(md) {
+  const out = [];
+  const seen = new Set();
+  const push = (id, text) => {
+    if (id && !seen.has(id)) { seen.add(id); out.push({ id, text: text.trim() }); }
+  };
+  for (const m of md.matchAll(/^\|\s*(AC-\d+)\s*\|(.+)$/gm)) {
+    push(m[1], m[2].split('|').map((c) => c.trim()).filter(Boolean).join(' — '));
+  }
+  for (const m of md.matchAll(/^\s*[-*]\s*\*\*(AC-\d+)\*\*\s*[—-]?\s*(.+)$/gm)) {
+    push(m[1], m[2]);
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+}

--- a/.github/plans/canvas-extensions-pack-prototype/package.json
+++ b/.github/plans/canvas-extensions-pack-prototype/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aldc-conductor-canvas-prototype",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "PROTOTYPE — al-conductor TDD pipeline canvas for the GitHub Copilot app. Reference spike for .github/plans/canvas-extensions-pack.md. Not shipped, not declared in aldc.yaml, no dependencies.",
+  "main": "extension.mjs",
+  "scripts": {
+    "demo": "node extension.mjs fixture sample-req"
+  }
+}

--- a/.github/plans/canvas-extensions-pack-prototype/review-audit.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/review-audit.mjs
@@ -1,0 +1,81 @@
+// C5 — Review/Audit Board canvas (read + HITL triage). See ../canvas-extensions-catalog.md §2/§5.
+// Backing artifact: the canonical Dredd Audit-Report JSON at .github/audits/dredd-audit-*.json
+// (owner: dredd; schema per agents/dredd.agent.md Step 4 — verdict PASS|PASS_WITH_FINDINGS|FAIL,
+// severity blocker|major|minor|info, findings[].location {file,line} + references[].path).
+//
+// TD-01 applied: Dredd's report is CI-validated and stays IMMUTABLE. Human triage decisions
+// (accept / dismiss / assign) are appended to a SIDECAR <audit>.triage.json that the next agent
+// (al-developer) consumes — the canvas never becomes a second source of truth.
+
+import { readFile, writeFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const SEVERITY_RANK = ['blocker', 'major', 'minor', 'info'];
+
+async function latestAuditFile(auditsDir) {
+  let files = [];
+  try { files = await readdir(auditsDir); } catch { return null; }
+  return files.filter((f) => /^dredd-audit-.*\.json$/.test(f)).sort().at(-1) ?? null;
+}
+
+const at = (f) => (f.location ? `${f.location.file}:${f.location.line}` : null);
+
+function normalizeFinding(f) {
+  return {
+    id: f.id,
+    severity: f.severity,
+    domain: f.domain,
+    source: f.source,
+    at: at(f),
+    message: f.message,
+    fixHint: f['fix-hint'] ?? null,
+    citation: f.references?.[0]?.path ?? null,
+  };
+}
+
+async function loadAudit(auditsDir) {
+  const file = await latestAuditFile(auditsDir);
+  if (!file) return { found: false, auditsDir };
+  const report = JSON.parse(await readFile(join(auditsDir, file), 'utf8'));
+  return {
+    found: true,
+    file,
+    verdict: report.audit?.verdict ?? 'UNKNOWN',
+    target: report.audit?.target ?? null,
+    bcqualitySha: report.audit?.bcquality?.['submodule-sha'] ?? null,
+    counts: report.summary?.counts ?? {},
+    findings: (report.findings ?? []).map(normalizeFinding),
+  };
+}
+
+function renderBoard(audit) {
+  const rank = (s) => { const i = SEVERITY_RANK.indexOf(s); return i < 0 ? 99 : i; };
+  const findings = [...(audit.findings ?? [])].sort((a, b) => rank(a.severity) - rank(b.severity));
+  return { verdict: audit.verdict, counts: audit.counts, bcqualitySha: audit.bcqualitySha, findings };
+}
+
+// HITL: append a triage decision to the sidecar; Dredd's JSON is never touched (TD-01).
+async function appendTriage(auditsDir, auditFile, decision) {
+  const sidecarName = auditFile.replace(/\.json$/, '.triage.json');
+  const sidecar = join(auditsDir, sidecarName);
+  let log = { audit: auditFile, decisions: [] };
+  try { log = JSON.parse(await readFile(sidecar, 'utf8')); } catch { /* first decision */ }
+  log.decisions.push({ ...decision, at: new Date().toISOString() });
+  await writeFile(sidecar, JSON.stringify(log, null, 2) + '\n');
+  return { sidecar: sidecarName, total: log.decisions.length };
+}
+
+export default function createReviewAuditCanvas(host, { auditsDir = '.github/audits' } = {}) {
+  const capabilities = {
+    loadAudit: () => loadAudit(auditsDir),
+    renderBoard: async () => renderBoard(await loadAudit(auditsDir)),
+    // decision = { findingId, action: 'accept' | 'dismiss' | 'assign', assignee?, note? }
+    triageFinding: async (decision) => {
+      const audit = await loadAudit(auditsDir);
+      if (!audit.found) throw new Error(`No dredd audit found in ${auditsDir}`);
+      return appendTriage(auditsDir, audit.file, decision);
+    },
+  };
+  // host?.registerCapabilities?.(capabilities); // ← official registration API TBD (preview)
+  return { capabilities, view: async () => renderBoard(await loadAudit(auditsDir)) };
+}

--- a/.github/plans/canvas-extensions-pack-prototype/spec-studio.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/spec-studio.mjs
@@ -1,0 +1,25 @@
+// C1 — Spec Studio canvas (read path). Backing artifact: {req}.spec.md (owner: /al-spec.create).
+// See ../canvas-extensions-catalog.md §2. Read-only for now; HITL writes (approve spec, edit AC)
+// follow the same append-to-markdown pattern as the Conductor canvas.
+
+import { join } from 'node:path';
+import { readIf, firstHeading, sectionHeadings, acceptanceCriteria } from './lib.mjs';
+
+async function loadSpec(planDir, reqName) {
+  const md = await readIf(join(planDir, reqName, `${reqName}.spec.md`));
+  return {
+    reqName,
+    title: firstHeading(md) || reqName,
+    sections: sectionHeadings(md),
+    acceptanceCriteria: acceptanceCriteria(md),
+  };
+}
+
+export default function createSpecStudioCanvas(host, { planDir = '.github/plans' } = {}) {
+  const capabilities = {
+    loadSpec: ({ reqName }) => loadSpec(planDir, reqName),
+    renderAcceptanceCriteria: async ({ reqName }) => (await loadSpec(planDir, reqName)).acceptanceCriteria,
+  };
+  // host?.registerCapabilities?.(capabilities); // ← official registration API TBD (preview)
+  return { capabilities, view: (reqName) => loadSpec(planDir, reqName) };
+}

--- a/.github/plans/canvas-extensions-pack-prototype/test-plan.mjs
+++ b/.github/plans/canvas-extensions-pack-prototype/test-plan.mjs
@@ -1,0 +1,21 @@
+// C3 — Test-Plan Checklist canvas (read path). Backing artifact: {req}.test-plan.md (skill-testing).
+// See ../canvas-extensions-catalog.md §2. Read-only for now; HITL writes (toggle AC, link test
+// codeunit) follow the same append-to-markdown pattern as the Conductor canvas.
+
+import { join } from 'node:path';
+import { readIf, firstHeading, acceptanceCriteria } from './lib.mjs';
+
+async function loadTestPlan(planDir, reqName) {
+  const md = await readIf(join(planDir, reqName, `${reqName}.test-plan.md`));
+  const criteria = acceptanceCriteria(md);
+  return { reqName, title: firstHeading(md) || reqName, total: criteria.length, criteria };
+}
+
+export default function createTestPlanCanvas(host, { planDir = '.github/plans' } = {}) {
+  const capabilities = {
+    loadTestPlan: ({ reqName }) => loadTestPlan(planDir, reqName),
+    renderCriteria: async ({ reqName }) => (await loadTestPlan(planDir, reqName)).criteria,
+  };
+  // host?.registerCapabilities?.(capabilities); // ← official registration API TBD (preview)
+  return { capabilities, view: (reqName) => loadTestPlan(planDir, reqName) };
+}

--- a/.github/plans/canvas-extensions-pack.md
+++ b/.github/plans/canvas-extensions-pack.md
@@ -1,0 +1,108 @@
+# Study — ALDC Canvas Extensions pack (GitHub Copilot app surface)
+
+**Status:** PROPOSED — awaiting go/no-go (HITL). Nothing shipped; this is a decision-ready proposal.
+**Scope:** A *new optional* **Extension-tier** pack. **No** changes to Core agents, workflows, or immutable templates.
+**Why:** GitHub Copilot's *canvases* are visible, steerable, bidirectional work surfaces. ALDC already **produces** the structured pipeline state (`spec.md`, `test-plan.md`, `*-phase-N-complete.md`, `memory.md`) that today lives as static markdown buried in the repo. A canvas turns that latent state into an inspectable, dirigible surface. ALDC is also **already multi-surface** (a top-level GitHub Copilot distribution + a `claude-plugin/` Claude Code distribution), so adding a Copilot-app surface extends an existing strategy rather than introducing a foreign concept.
+
+> This study follows the register of `.github/plans/claude-plugin-tool-modernization.md` (a framework-level study), **not** `docs/templates/architecture-template.md` — that template is for BC/AL *feature* architecture (Data Model, Permission sets, DataClassification) and does not fit a tooling pack.
+
+---
+
+## 1. What GitHub Copilot Canvas Extensions are
+
+A feature of the **GitHub Copilot app** — the agent-native *desktop* experience, in **technical preview** (availability expanded June 2026). A *canvas* is a **shared, interactive, bidirectional surface** for a work artifact (plan, triage board, browser session, release checklist, dashboard, incident, spreadsheet) that opens in the app's side panel. The agent updates the canvas while it works; the human edits / reorders / approves / redirects on that **same** surface, instead of the state being buried in a chat thread.
+
+**Runtime shape (confirmed from docs + community):**
+
+| Aspect | Detail |
+|--------|--------|
+| Location | One subdirectory per extension under `.github/extensions` (project scope) or `~/.copilot/extensions` (user scope) |
+| Manifest | `package.json` (metadata + dependencies) |
+| Entry point | **Must** be `extension.mjs` — **ES modules only** — defines canvas behavior + **agent-callable capabilities** |
+| State | Optional JSON artifacts for persisted canvas data/state |
+| Authoring | `/create-canvas` scaffolds; you iterate with the agent to add / remove / revise capabilities |
+| Interaction | Humans use UI actions; agents invoke the exposed *capabilities* against the same shared state |
+
+> **Host distinction (important):** ALDC's existing "Copilot" distribution targets **Copilot Chat inside VS Code** (uses `#problems` context-variables and the `ms-dynamics-smb.al/*` MCP). Canvas Extensions target the **standalone GitHub Copilot app** — same brand, **different runtime**. A canvas `extension.mjs` does **not** run in Claude Code or in VS Code Copilot Chat.
+
+## 2. Why it fits ALDC
+
+ALDC already emits the exact structured state a canvas wants to render — it just renders it as static markdown today. The mapping is close to 1:1:
+
+| ALDC artifact / agent (today) | Natural canvas |
+|---|---|
+| **`al-conductor`** TDD loop (plan→implement→review→commit, quality gates, HITL checkpoints, `*-phase-N-complete.md`) | **Pipeline / checklist** — RED-GREEN-REFACTOR + gates, visible and dirigible ⭐ **best pilot** |
+| `{req}.spec.md` + `{req}.test-plan.md` (acceptance criteria) | **Plan / checklist** (editable) |
+| `al-presales` (PERT, SWOT, cost) | **Dashboard** (estimate ranges, risk matrix) |
+| `al-triage` + `dredd` (findings, severity, recommended fix) | **Triage board** |
+| `/al-build` + `/al-pr-prepare` | **Release checklist** |
+
+## 3. Where it sits in the framework
+
+- **Tier:** Tier 3 — **Extension (MAY)**, identical tier to the existing **BC Agents pack** (`al-agent-builder` + 5 workflows + 3 skills).
+- **Hard constraints** (spec §Extension Packs): a pack **MUST NOT** override Core agents/workflows, modify the Core contract structure, or weaken HITL gates. This pack honors all three — it is **additive and read-mostly** over `.github/plans/`.
+- **Declared-equals-shipped** (spec §Validation): anything that ships **MUST** be declared in `aldc.yaml` (as *optional*) and accounted for in the spec's tier model; `check-conformance` / `sync-foundation` (CI) enforce this. So shipping the pack is a 3-part change: pack files + `aldc.yaml` entry + a spec tier-model line.
+- **Physical layout:** the pack's canvases live under `.github/extensions/aldc-<name>/` (the Copilot-app convention); ALDC pack metadata/docs live alongside the other packs. The markdown under `.github/plans/` remains untouched and authoritative.
+
+## 4. The pilot — `al-conductor` TDD pipeline canvas
+
+A single read-mostly canvas that makes a Conductor run visible and steerable. **The markdown in `.github/plans/` stays the source of truth; the canvas is a view/controller over it.**
+
+**Capability surface (names, not code):**
+
+| Capability | Direction | Reads / writes |
+|---|---|---|
+| `loadRun(reqName)` | read | `{req}.spec.md`, `{req}.architecture.md`, `{req}.test-plan.md` |
+| `renderPhases()` | read | derives RED-GREEN-REFACTOR + phase list from `*-phase-N-complete.md` |
+| `renderGates()` | read | quality gates + HITL checkpoints + skills/BCQuality evidence rows |
+| `approveGate(phaseId)` | **write (HITL)** | records human approval, appends to phase report |
+| `requestRevision(phaseId, note)` | **write (HITL)** | redirects the Conductor with a human note |
+| `syncMemory()` | read | surfaces relevant `.github/plans/memory.md` decisions |
+
+**Invariant:** the canvas never becomes a second source of truth. Every write goes back to the markdown artifact (git-versioned, PR-reviewable); the canvas re-derives its view from those files.
+
+## 5. Blocking decisions (HITL — for you)
+
+1. **Go / no-go now, or wait for GA?** Canvas is technical-preview; the API may shift. Adopt as an optional pack now, or shelve until GA?
+2. **Pilot scope:** Conductor canvas only (recommended), or also triage/estimation in the first cut?
+3. **Source-of-truth invariant:** confirm markdown-under-`.github/plans/` stays authoritative and the canvas is view/controller only (recommended).
+4. **Distribution host:** ship the pack from the top-level distribution, or as its own `packages/` package consumed by the collection?
+
+## 6. Proposed execution (only if approved)
+
+| Phase | Deliverable | Exit criterion |
+|---|---|---|
+| **P0 — Spike** | One read-only canvas reading a real `{req}.test-plan.md` in the Copilot app | Renders a live plan; no writes |
+| **P1 — Conductor (read)** | `loadRun` + `renderPhases` + `renderGates` | A real Conductor run renders phases + gates correctly |
+| **P2 — Conductor (HITL write)** | `approveGate` / `requestRevision` writing back to phase reports | A gate approval round-trips to markdown + git |
+| **P3 — Framework wiring** | `aldc.yaml` *optional* entry + spec tier-model line + docs | `check-conformance` green; declared-equals-shipped satisfied |
+| **P4 — Extend (optional)** | Triage board + estimation dashboard canvases | Each re-derives from existing artifacts only |
+
+## 7. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Preview API churn breaks the canvas | High | Med | Keep capabilities thin; pin pack as *optional*; isolate from Core so churn never blocks the pipeline |
+| New JS (`extension.mjs`) runtime = new security/governance surface vs. ALDC's *least-privilege* / *extension-only* ethos | Med | Med | No secrets/network in the pack; read-mostly; all writes go through git-visible markdown; document the trust boundary |
+| Two-host parity cost (Copilot app vs. existing surfaces) | Med | Low | Pack is additive & optional; nothing in Core depends on it; markdown remains the universal artifact |
+| Canvas drifts into a second source of truth | Low | High | Hard invariant (§4): canvas re-derives from `.github/plans/`; every write targets the markdown |
+
+## 8. Out of scope
+
+- **Core changes** — no Core agent/workflow/template is modified.
+- **VS Code Copilot Chat distribution** — unaffected; its `ms-dynamics-smb.al/*` references stay correct *there*.
+- **`claude-plugin/` (Claude Code)** — canvases do not run in that host; not a target.
+- **Replacing markdown artifacts** — explicitly *not* a goal; the canvas augments them.
+
+## Recommendation
+
+**Proceed — but as an optional Tier-3 Extension pack, piloting only the Conductor canvas, with markdown as the immutable source of truth.** The conceptual fit is strong and aligns with ALDC's existing multi-surface strategy; the only real costs (preview churn, a new JS runtime, two-host parity) are all contained by keeping the pack additive, read-mostly, and isolated from Core. Gate the start on the §5 decisions.
+
+---
+
+### References
+
+- Working with canvas extensions — GitHub Docs: `https://docs.github.com/en/copilot/how-tos/github-copilot-app/working-with-canvas-extensions`
+- GitHub Copilot app: the agent-native desktop experience — GitHub Blog: `https://github.blog/news-insights/product-news/github-copilot-app-the-agent-native-desktop-experience/`
+- Expanded technical preview availability — GitHub Changelog (2026-06-02): `https://github.blog/changelog/2026-06-02-expanded-technical-preview-availability-for-the-github-copilot-app/`
+- Canvas Extensions — Awesome GitHub Copilot: `https://awesome-copilot.github.com/extensions/`


### PR DESCRIPTION
## Qué es

Estudio **decision-ready** (no es implementación) sobre adoptar las **Canvas Extensions** de la GitHub Copilot app dentro de ALDC. Nace de la pregunta: *"¿qué opinas de añadir algo de esto al framework?"*

Documento: `.github/plans/canvas-extensions-pack.md` (registro de *estudio*, como `claude-plugin-tool-modernization.md` — no usa la plantilla de arquitectura AL, que no aplica a un pack de tooling).

## Recomendación

**Sí, pero como pack opcional Tier-3 (Extension), pilotando solo el canvas del `al-conductor`, con el markdown de `.github/plans/` como fuente de verdad.**

- Encaja porque ALDC **ya produce** el estado estructurado del pipeline (`spec.md`, `test-plan.md`, `*-phase-N-complete.md`) que hoy queda enterrado como markdown estático.
- Coherente con la estrategia multi-superficie que ALDC ya mantiene (Copilot Chat/VS Code + `claude-plugin/`). Ojo: Canvas es la **Copilot app** (preview), runtime distinto al de la distribución Copilot actual.
- **Additivo y read-mostly**: no toca Core, no debilita gates HITL, respeta las restricciones de *Extension Packs* y *declared-equals-shipped*.

## Decisiones bloqueantes (HITL)

1. ¿Go/no-go ahora o esperar a GA? (Canvas está en *technical preview*)
2. ¿Alcance del piloto = solo Conductor?
3. ¿Se confirma el invariante de fuente de verdad (markdown manda; canvas es vista/controlador)?
4. ¿Qué distribución lo aloja?

## Riesgos contenidos

Churn de la API en preview · nuevo runtime JS (`extension.mjs`) frente al *least-privilege* del framework · coste de paridad entre superficies · deriva a "segunda fuente de verdad". Todos mitigados manteniendo el pack opcional, aislado de Core y con toda escritura yendo al markdown versionado.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtP8csuXp5NntatU51iHgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtP8csuXp5NntatU51iHgn)_