### PR TITLE
feat(bcquality): consumir el nuevo índice de conocimiento de BCQuality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # ALDC Core Changelog
+## [Unreleased]
+
+### Added
+
+- **BCQuality knowledge index (Source-step acceleration)** — `tools/bcquality/install.{sh,ps1}` now build BCQuality's `knowledge-index.json` over the clone right after checkout, so the review skills' `Source` step reads one index file instead of every knowledge file's frontmatter. The index is **owned and produced by BCQuality** (its `tools/Build-KnowledgeIndex.ps1` generator); ALDC just runs it. Built **once at install** because ALDC consumes the full clone (no allow/deny pruning), and rebuilt on demand by `entry.md`'s preparation step. Fully defensive: a missing generator (older BCQuality), a missing `pwsh`, or a failed build all fall back to path-based discovery — never blocks. Documented in `docs/bcquality.md` and `tools/bcquality/README.md`.
+
 ## [4.2.0] - 2026-06-12
 
 ### Fixed

--- a/docs/bcquality.md
+++ b/docs/bcquality.md
@@ -34,6 +34,30 @@ reviews.
   Subagents consume that decision and do not re-probe — except `@dredd`/`@al-triage`
   run standalone, so they read `enabled` and probe themselves.
 
+## Knowledge index (Source-step acceleration)
+
+Recent BCQuality versions add a **knowledge index** — a single `knowledge-index.json`
+at the clone root that the review skills read at their `Source` step instead of
+opening every knowledge file to parse its frontmatter. It changes only **how**
+candidate knowledge files are discovered, never **which** are selected, so findings
+and citations are identical with or without it.
+
+- **Owned by BCQuality, not ALDC.** The generator (`tools/Build-KnowledgeIndex.ps1`)
+  ships inside the clone, next to the skills and knowledge it derives from. ALDC does
+  not re-implement the parser — it just runs that generator.
+- **Built once at install.** Because ALDC consumes the **full** clone (it filters by
+  `enabled-layers` / `disabled-skills` in the task-context, it does **not** prune the
+  clone by allow/deny policy), the index is stable between installs. The install
+  scripts build it right after the clone (`install.ps1` runs under PowerShell;
+  `install.sh` needs `pwsh` on `PATH`). `entry.md`'s preparation step rebuilds it on
+  demand at runtime if it is absent or stale, so the two paths reinforce each other.
+- **Never blocks.** A missing generator (older BCQuality), a missing `pwsh`, or a
+  failed build all fall back to path-based discovery. Review still works — it just
+  loses the index acceleration. Same principle as the absent-layer fallback: BCQuality
+  is additive and never fails the review.
+
+See `tools/bcquality/README.md` for the exact install-time behaviour.
+
 ## Install (only if you want BCQuality-backed reviews)
 
 From your **AL project root**:

--- a/tools/bcquality/README.md
+++ b/tools/bcquality/README.md
@@ -28,6 +28,18 @@ After completion they:
 - Verify `<home>/skills/entry.md` exists; fail loudly if not.
 - Print the actual HEAD SHA of the clone so you can confirm it matches `aldc.yaml`.
 - Warn if `aldc.yaml` doesn't record the same pin (the evidence validator would fail).
+- **Build the knowledge index** (`<home>/knowledge-index.json`) — see below.
+
+### Knowledge index (Source-step accelerator)
+
+Recent BCQuality versions ship a **knowledge index**: a single `knowledge-index.json` at the clone root that the review skills' `Source` step reads instead of opening every knowledge file just to parse its frontmatter. The index is **owned and produced by BCQuality** — its generator (`tools/Build-KnowledgeIndex.ps1`) lives inside the clone, next to the skills and knowledge it derives from — so ALDC never re-implements the parser; it just runs that generator once, here.
+
+After the clone is ready, the install scripts:
+
+1. Look for `<home>/tools/Build-KnowledgeIndex.ps1` in the clone. Absent (an older BCQuality with no index feature) → skip with a note; agents use path-based discovery.
+2. Present → run it over the clone (`-BCQualityRoot <home>`), writing `<home>/knowledge-index.json`. `install.ps1` already runs under PowerShell; `install.sh` needs `pwsh` (PowerShell 7+) on `PATH` and skips with a warning if it is missing.
+
+**This step is never fatal.** A missing generator, a missing `pwsh`, or a failed build all degrade to path-based discovery — review still works, just without the index acceleration. ALDC builds the index **once at install** (rather than per run) because ALDC consumes the **full** clone — it does not prune by allow/deny policy — so the index is stable between installs. `entry.md`'s own preparation step rebuilds the index on demand at runtime when it is absent or stale, so the two paths reinforce each other.
 
 The canonical pin lives in **three** places: `aldc.yaml` under `external.bcquality.pinnedCommit` (the source of truth) and the hardcoded `BCQUALITY_PIN` / `$BcqualityPin` in `install.sh` and `install.ps1`. If you ever bump the pin, update all three in the same commit — `validate_evidence.py` (and the `bcquality-evidence` CI workflow) fails the build if any of them drift.
 

--- a/tools/bcquality/install.ps1
+++ b/tools/bcquality/install.ps1
@@ -100,5 +100,32 @@ if ($BcqualityPin) {
     Warn "No pinnedCommit in aldc.yaml - tracking '$BcqualityRef'. Set external.bcquality.pinnedCommit to a 40-hex SHA for reproducible, evidence-validated runs."
 }
 
+# --- Build the knowledge index (BCQuality-owned Source-step accelerator) ---
+# The review skills' Source step reads <home>\knowledge-index.json instead of
+# opening every knowledge file just to read its frontmatter. The index is OWNED
+# and produced by BCQuality (tools\Build-KnowledgeIndex.ps1); ALDC simply runs
+# that generator over the clone once, here, because ALDC consumes the FULL clone
+# (it never prunes by allow/deny policy), so the index is stable between installs.
+# Everything below is defensive and NEVER fatal: a missing generator (older
+# BCQuality) or a failed build falls back to path-based discovery, and entry.md's
+# preparation step rebuilds the index on demand later. We already run under pwsh,
+# so no availability check is needed here.
+$indexGen = Join-Path $BcqualityHome 'tools\Build-KnowledgeIndex.ps1'
+if (Test-Path $indexGen) {
+    Say 'Building BCQuality knowledge index (Source-step accelerator)'
+    try {
+        & $indexGen -BCQualityRoot $BcqualityHome | Out-Null
+        if (Test-Path (Join-Path $BcqualityHome 'knowledge-index.json')) {
+            Say "knowledge-index.json ready at $BcqualityHome"
+        } else {
+            Warn 'Index generator ran but knowledge-index.json is missing - agents fall back to path-based discovery.'
+        }
+    } catch {
+        Warn "Index generator failed ($($_.Exception.Message)) - agents fall back to path-based discovery (never blocks)."
+    }
+} else {
+    Say 'This BCQuality version has no knowledge-index generator - agents use path-based discovery (no action needed).'
+}
+
 Say "Done. Open 'aldc.code-workspace' in VS Code - BCQuality appears as a second"
 Say "root the agents can read, while staying OUT of your extension's compilation."

--- a/tools/bcquality/install.sh
+++ b/tools/bcquality/install.sh
@@ -88,5 +88,34 @@ else
   warn "No pinnedCommit in aldc.yaml - tracking '$BCQUALITY_REF'. Set external.bcquality.pinnedCommit to a 40-hex SHA for reproducible, evidence-validated runs."
 fi
 
+# --- Build the knowledge index (BCQuality-owned Source-step accelerator) ---
+# The review skills' Source step reads <home>/knowledge-index.json instead of
+# opening every knowledge file just to read its frontmatter. The index is OWNED
+# and produced by BCQuality (tools/Build-KnowledgeIndex.ps1); ALDC simply runs
+# that generator over the clone once, here, because ALDC consumes the FULL clone
+# (it never prunes by allow/deny policy), so the index is stable between installs.
+# Everything below is defensive and NEVER fatal: a missing generator (older
+# BCQuality), a missing pwsh, or a failed build all fall back to path-based
+# discovery, and entry.md's preparation step rebuilds the index on demand later.
+INDEX_GEN="$BCQUALITY_HOME/tools/Build-KnowledgeIndex.ps1"
+if [ -f "$INDEX_GEN" ]; then
+  if command -v pwsh >/dev/null 2>&1; then
+    say "Building BCQuality knowledge index (Source-step accelerator)"
+    if pwsh -NoProfile -File "$INDEX_GEN" -BCQualityRoot "$BCQUALITY_HOME" >/dev/null; then
+      if [ -f "$BCQUALITY_HOME/knowledge-index.json" ]; then
+        say "knowledge-index.json ready at $BCQUALITY_HOME"
+      else
+        warn "Index generator ran but knowledge-index.json is missing - agents fall back to path-based discovery."
+      fi
+    else
+      warn "Index generator failed - agents fall back to path-based discovery (never blocks)."
+    fi
+  else
+    warn "pwsh (PowerShell 7+) not found - skipping knowledge-index build. Agents fall back to path-based discovery; entry.md rebuilds the index when pwsh is available."
+  fi
+else
+  say "This BCQuality version has no knowledge-index generator - agents use path-based discovery (no action needed)."
+fi
+
 say "Done. Open 'aldc.code-workspace' in VS Code - BCQuality appears as a second"
 say "root the agents can read, while staying OUT of your extension's compilation."


### PR DESCRIPTION
## Qué

BCQuality ha añadido una nueva capacidad: un **índice de conocimiento** (`knowledge-index.json`) que sus skills de review leen en el paso **Source** en lugar de abrir el frontmatter de cada fichero de conocimiento. Esta PR pone a ALDC a **consumir** esa capacidad.

El índice es **propiedad de BCQuality** (lo genera su `tools/Build-KnowledgeIndex.ps1`); ALDC no reimplementa el parser, solo ejecuta ese generador.

## Cambios

- **`tools/bcquality/install.sh` / `install.ps1`** — tras el clon, construyen `knowledge-index.json` sobre el clon ejecutando el generador de BCQuality.
- **`docs/bcquality.md`** — nueva sección "Knowledge index (Source-step acceleration)".
- **`tools/bcquality/README.md`** — documentado el paso de build en el lifecycle de install.
- **`CHANGELOG.md`** — entrada en `[Unreleased]`.

## Decisiones de diseño

- **Build una vez en install, no por run.** El motivo de BCQuality para "reconstruir cada run sobre el clon podado" es para consumidores que **borran** capas por política. ALDC **no poda**: filtra vía `enabled-layers` / `disabled-skills` / `pilotSkills` en el task-context. Por eso el índice = corpus completo y es **estable entre installs**, y construirlo una vez es lo idiomático (no exige `pwsh` en el runtime del agente). El paso *Preparation* de `entry.md` lo reconstruye en runtime si falta o está obsoleto — ambos caminos se refuerzan.
- **Nunca bloquea.** Generador ausente (BCQuality antiguo), `pwsh` ausente, o build fallido → todos caen a *path-based discovery*. El review sigue funcionando, solo pierde la aceleración. Mismo principio que el fallback de capa ausente: BCQuality es aditivo y nunca falla el review.
- **Fuente sin cambios.** `external.bcquality.url` sigue en upstream `microsoft/BCQuality` (configurable). Esta PR no cambia la fuente.
- **Prosa de los agentes intacta.** El índice es propiedad de BCQuality y `entry.md` posee el paso *Preparation*; al construirlo en install, el paso del agente lo encuentra presente y es un no-op. Se evita así tocar las múltiples copias de los agentes.

## Verificación

- `bash -n tools/bcquality/install.sh` → OK.
- `install.ps1` revisado manualmente (try/catch en lugar de `$LASTEXITCODE`, que no es fiable tras invocar un `.ps1`). No había `pwsh` en el entorno para parse-check automático — que es exactamente el caso que el fallback de `install.sh` cubre.

> [!NOTE]
> A confirmar al clonar: si el upstream `microsoft/BCQuality` aún no ha mergeado `tools/Build-KnowledgeIndex.ps1`, el paso de install se salta con un aviso (sin romper) hasta que la capacidad llegue upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013i5qwqRTzBPxHxYxUzFYmY)_