### PR TITLE
fix(claude-plugin): remove leftover VS Code Copilot tool references

### DIFF
--- a/.claude/skills/skill-debug/SKILL.md
+++ b/.claude/skills/skill-debug/SKILL.md
@@ -42,7 +42,7 @@ Scenario: "Value is wrong after posting"
 
 1. Set breakpoint at final location (where value is wrong)
 2. Work backwards to find where value is set
-3. Use `usages` tool to find all assignments
+3. Use al-symbols-mcp `al_find_references` (or `Grep` for text search) to find all assignments
 4. Set breakpoints at each assignment point
 5. Step through to find which execution path is taken
 6. Inspect conditions and variable states at each point
@@ -130,7 +130,7 @@ Gather issue information:
 
 ### Step 2a: Isolate the Problem (Runtime / Logic)
 
-1. Narrow down scope with `search` and `usages` tools
+1. Narrow down scope with `Grep`/`Glob` and al-symbols-mcp `al_find_references`
 2. Identify suspect objects (tables, pages, codeunits, event subscribers)
 3. Attach debugger with selected strategy (Pattern 1)
 4. Set strategic breakpoints:

--- a/.claude/skills/skill-performance/SKILL.md
+++ b/.claude/skills/skill-performance/SKILL.md
@@ -241,7 +241,7 @@ Avoid FlowFields:
 
 Scan the codebase before profiling to identify structural issues:
 
-Patterns to detect manually or with `search` + `problems`:
+Patterns to detect manually with `Grep`/`Glob`, or from compiler warnings in `al compile` output:
 - `FindSet()` / `FindFirst()` without preceding `SetRange` / `SetFilter`
 - `SetLoadFields` placed after `SetRange` (wrong order)
 - Database calls (`Get`, `FindSet`, `FindFirst`) inside `repeat...until`

--- a/claude-plugin/commands/al-pr-prepare.md
+++ b/claude-plugin/commands/al-pr-prepare.md
@@ -25,14 +25,10 @@ Your goal is to prepare a **pull request draft** for the branch `${input:Branch}
 
 #### Inspect Branch Differences
 
-Use `codebase` to analyze modifications:
-```
-codebase: Compare ${input:Branch} with main branch
-```
-
-Use `githubRepo` to gather context:
-```
-githubRepo: Get branch information and commit history
+Compare the branch against main with `Bash`:
+```bash
+git diff main...${input:Branch} --stat
+git log main..${input:Branch} --oneline
 ```
 
 **Gather:**

--- a/claude-plugin/skills/skill-debug/SKILL.md
+++ b/claude-plugin/skills/skill-debug/SKILL.md
@@ -42,7 +42,7 @@ Scenario: "Value is wrong after posting"
 
 1. Set breakpoint at final location (where value is wrong)
 2. Work backwards to find where value is set
-3. Use `usages` tool to find all assignments
+3. Use al-symbols-mcp `al_find_references` (or `Grep` for text search) to find all assignments
 4. Set breakpoints at each assignment point
 5. Step through to find which execution path is taken
 6. Inspect conditions and variable states at each point
@@ -130,7 +130,7 @@ Gather issue information:
 
 ### Step 2a: Isolate the Problem (Runtime / Logic)
 
-1. Narrow down scope with `search` and `usages` tools
+1. Narrow down scope with `Grep`/`Glob` and al-symbols-mcp `al_find_references`
 2. Identify suspect objects (tables, pages, codeunits, event subscribers)
 3. Attach debugger with selected strategy (Pattern 1)
 4. Set strategic breakpoints:

--- a/claude-plugin/skills/skill-performance/SKILL.md
+++ b/claude-plugin/skills/skill-performance/SKILL.md
@@ -241,7 +241,7 @@ Avoid FlowFields:
 
 Scan the codebase before profiling to identify structural issues:
 
-Patterns to detect manually or with `search` + `problems`:
+Patterns to detect manually with `Grep`/`Glob`, or from compiler warnings in `al compile` output:
 - `FindSet()` / `FindFirst()` without preceding `SetRange` / `SetFilter`
 - `SetLoadFields` placed after `SetRange` (wrong order)
 - Database calls (`Get`, `FindSet`, `FindFirst`) inside `repeat...until`


### PR DESCRIPTION
## Summary
- `skill-debug/SKILL.md` and `skill-performance/SKILL.md` still referenced VS Code Copilot Chat context-variables (`` `usages` ``, `` `search` ``, `` `problems` ``) that `claude-plugin/CLAUDE.md` explicitly says do not exist on this surface ("agent prose must not invoke them as if they were tools").
- `al-pr-prepare.md` referenced `` `codebase` `` / `` `githubRepo` `` the same way.
- Mapped each to what's actually available per the canonical tool table in `claude-plugin/CLAUDE.md`: al-symbols-mcp `al_find_references`, `Grep`/`Glob`, and `git diff`/`git log` via `Bash`.

Found while auditing the plugin for remaining Copilot/VS-Code vocabulary drift after #69 and #88.

## Test plan
- [x] `node tools/aldc-validate/index.js` — confirms ALDC Core compliance unaffected (docs-only change, no object/skill structure change)
- [ ] Maintainer spot-check: no other stale tool references remain in `claude-plugin/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsqSdx3JtADPvj7ep7F877)_