### PR TITLE
Use the official Microsoft Learn MCP endpoint for microsoft-docs

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -34,9 +34,8 @@
       "url": "https://mcp.context7.com/mcp"
     },
     "microsoft-docs": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@nicholasglazer/microsoft-docs-mcp"]
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
     }
   },
   "userConfig": {

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -10,9 +10,8 @@
       "url": "https://mcp.context7.com/mcp"
     },
     "microsoft-docs": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@nicholasglazer/microsoft-docs-mcp"]
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
     }
   }
 }


### PR DESCRIPTION
Point the `microsoft-docs` MCP server at Microsoft's official hosted endpoint instead of the community npx wrapper.

**What changes**

`microsoft-docs` becomes an `http` server on `https://learn.microsoft.com/api/mcp`, replacing `npx -y @nicholasglazer/microsoft-docs-mcp`. Applied to both `claude-plugin/.claude-plugin/plugin.json` and `claude-plugin/.mcp.json` so the two stay consistent.

**Why**

- It is Microsoft's own remote MCP server, backing the same Learn knowledge service as Ask Learn and Copilot for Azure.
- No `npx` fetch on every client start, and no Node dependency for this server.
- Streamable HTTP, no authentication required.

**Notes**

Running in our fork against ALDC v4.2.0. This only touches `microsoft-docs`; `al-symbols-mcp` and `context7` are untouched.

Docs: https://learn.microsoft.com/en-us/training/support/mcp