### PR TITLE
refactor(brand): simplify and strengthen the ALDC mark

### DIFF
--- a/docs/assets/images/aldc-favicon.svg
+++ b/docs/assets/images/aldc-favicon.svg
@@ -6,5 +6,5 @@
   <circle cx="32.4" cy="14.8" r="3.6" fill="#38BDF8"/>
   <circle cx="14.5" cy="47.5" r="3.2" fill="#38BDF8"/>
   <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
-  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width=".8" stroke-linejoin="round"/>
 </svg>

--- a/docs/assets/images/aldc-favicon.svg
+++ b/docs/assets/images/aldc-favicon.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="13" fill="#0F172A"/>
-  <path d="M13 32H51" stroke="#38BDF8" stroke-width="4" stroke-linecap="round"/>
-  <rect x="9" y="23" width="16" height="18" rx="3" fill="#E0F7FF" stroke="#38BDF8" stroke-width="2"/>
-  <rect x="28" y="23" width="11" height="18" rx="3" fill="#0E7490" stroke="#38BDF8" stroke-width="2"/>
-  <rect x="42" y="23" width="13" height="18" rx="3" fill="#FCE7F3" stroke="#D946EF" stroke-width="2"/>
-  <path d="M45 32L48 35L53 28" fill="none" stroke="#A21CAF" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="2" y="2" width="60" height="60" rx="15" fill="#0F172A"/>
+  <path d="M14.5 47.5L28.8 17.8C30 15.2 31 14 32.4 14C33.8 14 34.8 15.2 36 17.8L50 47.5"
+        fill="none" stroke="#F8FAFC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M21.5 35.5H42.5" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="32.4" cy="14.8" r="3.6" fill="#38BDF8"/>
+  <circle cx="14.5" cy="47.5" r="3.2" fill="#38BDF8"/>
+  <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
+  <rect x="37.6" y="30.6" width="9.8" height="9.8" rx="2.2" fill="#D946EF" stroke="#0F172A" stroke-width="2"/>
 </svg>

--- a/docs/assets/images/aldc-favicon.svg
+++ b/docs/assets/images/aldc-favicon.svg
@@ -2,9 +2,9 @@
   <rect x="2" y="2" width="60" height="60" rx="15" fill="#0F172A"/>
   <path d="M14.5 47.5L28.8 17.8C30 15.2 31 14 32.4 14C33.8 14 34.8 15.2 36 17.8L50 47.5"
         fill="none" stroke="#F8FAFC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M21.5 35.5H42.5" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
+  <path d="M21.5 35.5H38" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
   <circle cx="32.4" cy="14.8" r="3.6" fill="#38BDF8"/>
   <circle cx="14.5" cy="47.5" r="3.2" fill="#38BDF8"/>
   <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
-  <rect x="37.6" y="30.6" width="9.8" height="9.8" rx="2.2" fill="#D946EF" stroke="#0F172A" stroke-width="2"/>
+  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width="2" stroke-linejoin="round"/>
 </svg>

--- a/docs/assets/images/aldc-mark.svg
+++ b/docs/assets/images/aldc-mark.svg
@@ -13,5 +13,5 @@
   <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
 
   <!-- Magenta is reserved for the human judgment gate. -->
-  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width=".8" stroke-linejoin="round"/>
 </svg>

--- a/docs/assets/images/aldc-mark.svg
+++ b/docs/assets/images/aldc-mark.svg
@@ -6,12 +6,12 @@
   <!-- The A is a system path: two structural traces, three evidence nodes. -->
   <path d="M14.5 47.5L28.8 17.8C30 15.2 31 14 32.4 14C33.8 14 34.8 15.2 36 17.8L50 47.5"
         fill="none" stroke="#F8FAFC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M21.5 35.5H42.5" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
+  <path d="M21.5 35.5H38" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
 
   <circle cx="32.4" cy="14.8" r="3.6" fill="#38BDF8"/>
   <circle cx="14.5" cy="47.5" r="3.2" fill="#38BDF8"/>
   <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
 
   <!-- Magenta is reserved for the human judgment gate. -->
-  <rect x="37.6" y="30.6" width="9.8" height="9.8" rx="2.2" fill="#D946EF" stroke="#0F172A" stroke-width="2"/>
+  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width="2" stroke-linejoin="round"/>
 </svg>

--- a/docs/assets/images/aldc-mark.svg
+++ b/docs/assets/images/aldc-mark.svg
@@ -1,12 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
   <title id="title">ALDC mark</title>
-  <desc id="desc">Four connected engineering modules with a magenta human decision mark.</desc>
-  <rect x="2" y="2" width="60" height="60" rx="12" fill="#0F172A"/>
-  <path d="M16 32H48" fill="none" stroke="#38BDF8" stroke-width="3" stroke-linecap="round"/>
-  <rect x="10" y="24" width="14" height="16" rx="3" fill="#E0F7FF" stroke="#38BDF8" stroke-width="2"/>
-  <rect x="27" y="24" width="10" height="16" rx="3" fill="#0E7490" stroke="#38BDF8" stroke-width="2"/>
-  <rect x="40" y="24" width="14" height="16" rx="3" fill="#FCE7F3" stroke="#D946EF" stroke-width="2"/>
-  <path d="M44 31L47 34L52 27" fill="none" stroke="#A21CAF" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="16" cy="18" r="2" fill="#D946EF"/>
-  <path d="M16 20V24" stroke="#D946EF" stroke-width="2" stroke-linecap="round"/>
+  <desc id="desc">A circuit-built letter A with a magenta human decision gate.</desc>
+  <rect x="2" y="2" width="60" height="60" rx="15" fill="#0F172A"/>
+
+  <!-- The A is a system path: two structural traces, three evidence nodes. -->
+  <path d="M14.5 47.5L28.8 17.8C30 15.2 31 14 32.4 14C33.8 14 34.8 15.2 36 17.8L50 47.5"
+        fill="none" stroke="#F8FAFC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M21.5 35.5H42.5" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
+
+  <circle cx="32.4" cy="14.8" r="3.6" fill="#38BDF8"/>
+  <circle cx="14.5" cy="47.5" r="3.2" fill="#38BDF8"/>
+  <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
+
+  <!-- Magenta is reserved for the human judgment gate. -->
+  <rect x="37.6" y="30.6" width="9.8" height="9.8" rx="2.2" fill="#D946EF" stroke="#0F172A" stroke-width="2"/>
 </svg>


### PR DESCRIPTION
## Summary

Replaces the first ALDC icon with a simpler, more recognizable mark that remains legible at favicon size.

### Design rationale

- **A-shaped system path**: a clear AL/agentic anchor without placing tiny letters inside the icon.
- **Three cyan nodes**: evidence and traceability across the engineering system.
- **Single magenta gate**: human judgment remains visible, but is no longer competing with the structure.
- **Flat vector geometry**: crisp at 16 px, scalable, editable and consistent with the technical-paper identity.

### Changed

- `docs/assets/images/aldc-mark.svg`
- `docs/assets/images/aldc-favicon.svg`

### Validation

- SVG files parse as valid XML.
- `npm test`: 0 errors.
- `python -m mkdocs build --clean`: successful.
- Existing repository warnings remain unchanged and are unrelated to this update.
