### PR TITLE
refactor(brand): move ALDC toward an engineering notebook

### DIFF
--- a/docs/assets/images/aldc-brand-banner.svg
+++ b/docs/assets/images/aldc-brand-banner.svg
@@ -3,76 +3,76 @@
   <desc id="desc">Technical paper banner showing a traceable agentic engineering flow with human review.</desc>
   <defs>
     <pattern id="minorGrid" width="8" height="8" patternUnits="userSpaceOnUse">
-      <path d="M8 0H0V8" fill="none" stroke="#0891B2" stroke-opacity=".035" stroke-width="1"/>
+      <path d="M8 0H0V8" fill="none" stroke="#1E2160" stroke-opacity=".025" stroke-width="1"/>
     </pattern>
     <pattern id="majorGrid" width="32" height="32" patternUnits="userSpaceOnUse">
       <rect width="32" height="32" fill="url(#minorGrid)"/>
-      <path d="M32 0H0V32" fill="none" stroke="#0F172A" stroke-opacity=".07" stroke-width="1"/>
+      <path d="M32 0H0V32" fill="none" stroke="#1E2160" stroke-opacity=".075" stroke-width="1"/>
     </pattern>
     <linearGradient id="accent" x1="0" x2="1">
-      <stop offset="0" stop-color="#38BDF8"/>
-      <stop offset=".72" stop-color="#0891B2"/>
-      <stop offset=".72" stop-color="#D946EF"/>
-      <stop offset="1" stop-color="#A21CAF"/>
+      <stop offset="0" stop-color="#22CCE0"/>
+      <stop offset=".72" stop-color="#0B8293"/>
+      <stop offset=".72" stop-color="#C72F83"/>
+      <stop offset="1" stop-color="#98225F"/>
     </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="160%">
-      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#0F172A" flood-opacity=".09"/>
+      <feDropShadow dx="3" dy="3" stdDeviation="0" flood-color="#1E2160" flood-opacity=".07"/>
     </filter>
   </defs>
 
-  <rect x="1" y="1" width="1278" height="418" rx="18" fill="#F7F9F8" stroke="#B8C9D3" stroke-width="2"/>
+  <rect x="1" y="1" width="1278" height="418" rx="3" fill="#F6F3EC" stroke="#C9C5BD" stroke-width="2"/>
   <rect x="1" y="1" width="1278" height="418" rx="18" fill="url(#majorGrid)"/>
-  <rect x="1" y="1" width="1278" height="7" rx="4" fill="url(#accent)"/>
+  <rect x="1" y="1" width="1278" height="5" fill="#1E2160"/>
 
   <g font-family="Inter, Segoe UI, Arial, sans-serif">
     <g transform="translate(72 58)">
-      <rect width="166" height="30" rx="4" fill="#E0F7FF" stroke="#38BDF8"/>
-      <text x="15" y="20" fill="#0E7490" font-family="JetBrains Mono, Consolas, monospace" font-size="13" font-weight="700" letter-spacing="1.5">OPEN ENGINEERING</text>
-      <text x="184" y="20" fill="#64748B" font-family="JetBrains Mono, Consolas, monospace" font-size="13" font-weight="600">// BUSINESS CENTRAL</text>
+      <rect width="166" height="30" rx="2" fill="#E3F6F4" stroke="#22CCE0"/>
+      <text x="15" y="20" fill="#0B8293" font-family="JetBrains Mono, Consolas, monospace" font-size="13" font-weight="700" letter-spacing="1.5">OPEN ENGINEERING</text>
+      <text x="184" y="20" fill="#626274" font-family="JetBrains Mono, Consolas, monospace" font-size="13" font-weight="600">// BUSINESS CENTRAL</text>
     </g>
 
-    <text x="70" y="205" fill="#0F172A" font-size="104" font-weight="800" letter-spacing="-6">ALDC</text>
-    <rect x="72" y="225" width="116" height="5" fill="#38BDF8"/>
-    <rect x="188" y="225" width="48" height="5" fill="#D946EF"/>
-    <text x="72" y="276" fill="#263548" font-size="32" font-weight="700" letter-spacing="-.7">AL Agentic Engineering System</text>
-    <text x="72" y="321" fill="#64748B" font-size="22">Structured delivery. Traceable decisions. Human-governed AI.</text>
+    <text x="70" y="205" fill="#1E2160" font-size="104" font-weight="800" letter-spacing="-6">ALDC</text>
+    <rect x="72" y="225" width="116" height="5" fill="#22CCE0"/>
+    <rect x="188" y="225" width="48" height="5" fill="#C72F83"/>
+    <text x="72" y="276" fill="#35364F" font-size="32" font-weight="700" letter-spacing="-.7">AL Agentic Engineering System</text>
+    <text x="72" y="321" fill="#626274" font-size="22">Structured delivery. Traceable decisions. Human-governed AI.</text>
     <g transform="translate(88 354) rotate(-1)">
-      <path d="M0 9H22" stroke="#D946EF" stroke-width="2" stroke-linecap="round"/>
-      <path d="M17 4L23 9L17 14" fill="none" stroke="#D946EF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-      <text x="34" y="15" fill="#A21CAF" font-size="18" font-style="italic" font-weight="650">Engineering systems, visibly reasoned.</text>
+      <path d="M0 9H22" stroke="#C72F83" stroke-width="2" stroke-linecap="round"/>
+      <path d="M17 4L23 9L17 14" fill="none" stroke="#C72F83" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="34" y="15" fill="#98225F" font-size="18" font-style="italic" font-weight="650">Engineering systems, visibly reasoned.</text>
     </g>
   </g>
 
   <g transform="translate(730 88)" filter="url(#shadow)" font-family="JetBrains Mono, Consolas, monospace">
-    <path d="M70 108H408" fill="none" stroke="#38BDF8" stroke-width="4" stroke-linecap="round"/>
-    <circle cx="70" cy="108" r="7" fill="#D946EF"/>
-    <circle cx="408" cy="108" r="7" fill="#D946EF"/>
+    <path d="M70 108H408" fill="none" stroke="#22CCE0" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="70" cy="108" r="7" fill="#C72F83"/>
+    <circle cx="408" cy="108" r="7" fill="#C72F83"/>
 
     <g transform="translate(0 62)">
-      <rect width="140" height="92" rx="9" fill="#FFFFFF" fill-opacity=".96" stroke="#38BDF8" stroke-width="2"/>
-      <text x="18" y="30" fill="#0891B2" font-size="12" font-weight="700" letter-spacing="1.5">01 / ARCH</text>
-      <path d="M18 49H104M18 62H84" stroke="#B8C9D3" stroke-width="3" stroke-linecap="round"/>
-      <circle cx="112" cy="66" r="9" fill="#E0F7FF" stroke="#38BDF8"/>
+      <rect width="140" height="92" rx="3" fill="#FBF8F1" fill-opacity=".96" stroke="#22CCE0" stroke-width="2"/>
+      <text x="18" y="30" fill="#0B8293" font-size="12" font-weight="700" letter-spacing="1.5">01 / ARCH</text>
+      <path d="M18 49H104M18 62H84" stroke="#C9C5BD" stroke-width="3" stroke-linecap="round"/>
+      <circle cx="112" cy="66" r="9" fill="#E3F6F4" stroke="#22CCE0"/>
     </g>
     <g transform="translate(122 0)">
-      <rect width="140" height="92" rx="9" fill="#FFFFFF" fill-opacity=".96" stroke="#38BDF8" stroke-width="2"/>
-      <text x="18" y="30" fill="#0891B2" font-size="12" font-weight="700" letter-spacing="1.5">02 / SPEC</text>
-      <path d="M18 49H104M18 62H84" stroke="#B8C9D3" stroke-width="3" stroke-linecap="round"/>
-      <rect x="104" y="54" width="18" height="18" rx="3" fill="#E0F7FF" stroke="#38BDF8"/>
+      <rect width="140" height="92" rx="3" fill="#FBF8F1" fill-opacity=".96" stroke="#22CCE0" stroke-width="2"/>
+      <text x="18" y="30" fill="#0B8293" font-size="12" font-weight="700" letter-spacing="1.5">02 / SPEC</text>
+      <path d="M18 49H104M18 62H84" stroke="#C9C5BD" stroke-width="3" stroke-linecap="round"/>
+      <rect x="104" y="54" width="18" height="18" rx="2" fill="#E3F6F4" stroke="#22CCE0"/>
     </g>
     <g transform="translate(244 124)">
-      <rect width="140" height="92" rx="9" fill="#0F172A" stroke="#38BDF8" stroke-width="2"/>
+      <rect width="140" height="92" rx="3" fill="#1E2160" stroke="#22CCE0" stroke-width="2"/>
       <text x="18" y="30" fill="#91E3FA" font-size="12" font-weight="700" letter-spacing="1.5">03 / BUILD</text>
       <path d="M18 49H104M18 62H84" stroke="#587287" stroke-width="3" stroke-linecap="round"/>
-      <path d="M108 56L115 63L125 49" fill="none" stroke="#38BDF8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M108 56L115 63L125 49" fill="none" stroke="#22CCE0" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
     <g transform="translate(366 62)">
-      <rect width="140" height="92" rx="9" fill="#FCE7F3" fill-opacity=".96" stroke="#D946EF" stroke-width="2"/>
-      <text x="18" y="30" fill="#A21CAF" font-size="12" font-weight="700" letter-spacing="1.5">04 / REVIEW</text>
+      <rect width="140" height="92" rx="3" fill="#F5DCE8" fill-opacity=".96" stroke="#C72F83" stroke-width="2"/>
+      <text x="18" y="30" fill="#98225F" font-size="12" font-weight="700" letter-spacing="1.5">04 / REVIEW</text>
       <path d="M18 49H96M18 62H76" stroke="#D6A5D8" stroke-width="3" stroke-linecap="round"/>
-      <path d="M101 57L110 66L126 45" fill="none" stroke="#A21CAF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M101 57L110 66L126 45" fill="none" stroke="#98225F" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <text x="118" y="264" fill="#64748B" font-size="12" letter-spacing="1">EVIDENCE → DECISION → CONTROL</text>
-    <path d="M93 250C180 278 288 278 398 248" fill="none" stroke="#D946EF" stroke-width="2" stroke-linecap="round" stroke-dasharray="6 7"/>
+    <text x="118" y="264" fill="#626274" font-size="12" letter-spacing="1">EVIDENCE → DECISION → CONTROL</text>
+    <path d="M93 250C180 278 288 278 398 248" fill="none" stroke="#C72F83" stroke-width="2" stroke-linecap="round" stroke-dasharray="6 7"/>
   </g>
 </svg>

--- a/docs/assets/images/aldc-brand-banner.svg
+++ b/docs/assets/images/aldc-brand-banner.svg
@@ -21,7 +21,7 @@
   </defs>
 
   <rect x="1" y="1" width="1278" height="418" rx="3" fill="#F6F3EC" stroke="#C9C5BD" stroke-width="2"/>
-  <rect x="1" y="1" width="1278" height="418" rx="18" fill="url(#majorGrid)"/>
+  <rect x="1" y="1" width="1278" height="418" rx="3" fill="url(#majorGrid)"/>
   <rect x="1" y="1" width="1278" height="5" fill="#1E2160"/>
 
   <g font-family="Inter, Segoe UI, Arial, sans-serif">

--- a/docs/assets/images/aldc-favicon.svg
+++ b/docs/assets/images/aldc-favicon.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect x="2" y="2" width="60" height="60" rx="15" fill="#0F172A"/>
+  <rect x="2" y="2" width="60" height="60" rx="15" fill="#1E2160"/>
   <path d="M14.5 47.5L28.8 17.8C30 15.2 31 14 32.4 14C33.8 14 34.8 15.2 36 17.8L50 47.5"
         fill="none" stroke="#F8FAFC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M21.5 35.5H38" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
-  <circle cx="32.4" cy="14.8" r="3.6" fill="#38BDF8"/>
-  <circle cx="14.5" cy="47.5" r="3.2" fill="#38BDF8"/>
-  <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
-  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width=".8" stroke-linejoin="round"/>
+  <path d="M21.5 35.5H38" fill="none" stroke="#22CCE0" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="32.4" cy="14.8" r="3.6" fill="#22CCE0"/>
+  <circle cx="14.5" cy="47.5" r="3.2" fill="#22CCE0"/>
+  <circle cx="50" cy="47.5" r="3.2" fill="#22CCE0"/>
+  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#C72F83" stroke="#1E2160" stroke-width=".8" stroke-linejoin="round"/>
 </svg>

--- a/docs/assets/images/aldc-mark.svg
+++ b/docs/assets/images/aldc-mark.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
   <title id="title">ALDC mark</title>
   <desc id="desc">A circuit-built letter A with a magenta human decision gate.</desc>
-  <rect x="2" y="2" width="60" height="60" rx="15" fill="#0F172A"/>
+  <rect x="2" y="2" width="60" height="60" rx="15" fill="#1E2160"/>
 
   <!-- The A is a system path: two structural traces, three evidence nodes. -->
   <path d="M14.5 47.5L28.8 17.8C30 15.2 31 14 32.4 14C33.8 14 34.8 15.2 36 17.8L50 47.5"
         fill="none" stroke="#F8FAFC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M21.5 35.5H38" fill="none" stroke="#38BDF8" stroke-width="5" stroke-linecap="round"/>
+  <path d="M21.5 35.5H38" fill="none" stroke="#22CCE0" stroke-width="5" stroke-linecap="round"/>
 
-  <circle cx="32.4" cy="14.8" r="3.6" fill="#38BDF8"/>
-  <circle cx="14.5" cy="47.5" r="3.2" fill="#38BDF8"/>
-  <circle cx="50" cy="47.5" r="3.2" fill="#38BDF8"/>
+  <circle cx="32.4" cy="14.8" r="3.6" fill="#22CCE0"/>
+  <circle cx="14.5" cy="47.5" r="3.2" fill="#22CCE0"/>
+  <circle cx="50" cy="47.5" r="3.2" fill="#22CCE0"/>
 
   <!-- Magenta is reserved for the human judgment gate. -->
-  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#D946EF" stroke="#0F172A" stroke-width=".8" stroke-linejoin="round"/>
+  <path d="M42.5 29.8L48.2 35.5L42.5 41.2L36.8 35.5Z" fill="#C72F83" stroke="#1E2160" stroke-width=".8" stroke-linejoin="round"/>
 </svg>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,65 +1,65 @@
 /* =========================================================
    ALDC — Open Engineering visual system
-   Technical paper · visible reasoning · human judgement
+   Engineering notebook · visible reasoning · human judgement
    ========================================================= */
 
 :root,
 [data-md-color-scheme="default"],
 [data-md-color-scheme="slate"] {
-  --oe-paper: #f7f9f8;
-  --oe-paper-deep: #eef3f5;
-  --oe-surface: #ffffff;
-  --oe-navy: #0f172a;
-  --oe-navy-soft: #17243a;
-  --oe-text: #263548;
-  --oe-muted: #64748b;
-  --oe-line: #d7e2e8;
-  --oe-line-strong: #b8c9d3;
-  --oe-cyan: #0e7490;
-  --oe-cyan-bright: #38bdf8;
-  --oe-cyan-soft: #e0f7ff;
-  --oe-magenta: #d946ef;
-  --oe-magenta-deep: #a21caf;
-  --oe-magenta-soft: #fce7f3;
+  --oe-paper: #f6f3ec;
+  --oe-paper-deep: #eeeae1;
+  --oe-surface: #fbf8f1;
+  --oe-navy: #1e2160;
+  --oe-navy-soft: #2f316b;
+  --oe-text: #35364f;
+  --oe-muted: #626274;
+  --oe-line: #e6e3dd;
+  --oe-line-strong: #c9c5bd;
+  --oe-cyan: #0b8293;
+  --oe-cyan-bright: #22cce0;
+  --oe-cyan-soft: #e3f6f4;
+  --oe-magenta: #c72f83;
+  --oe-magenta-deep: #98225f;
+  --oe-magenta-soft: #f5dce8;
   --oe-success: #0f766e;
-  --oe-radius-card: 10px;
-  --oe-radius-small: 4px;
-  --oe-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.05);
-  --oe-shadow-md: 0 12px 30px rgba(15, 23, 42, 0.08);
-  --oe-shadow-cyan: 0 10px 28px rgba(8, 145, 178, 0.18);
+  --oe-radius-card: 3px;
+  --oe-radius-small: 2px;
+  --oe-shadow-sm: 2px 2px 0 rgba(30, 33, 96, 0.05);
+  --oe-shadow-md: 4px 4px 0 rgba(30, 33, 96, 0.07);
+  --oe-shadow-cyan: 3px 3px 0 rgba(34, 204, 224, 0.22);
 
   --md-primary-fg-color: var(--oe-navy);
   --md-primary-fg-color--light: var(--oe-navy-soft);
-  --md-primary-fg-color--dark: #080f1e;
+  --md-primary-fg-color--dark: #141643;
   --md-primary-bg-color: var(--oe-paper);
   --md-primary-bg-color--light: var(--oe-surface);
   --md-accent-fg-color: var(--oe-cyan);
-  --md-accent-fg-color--transparent: rgba(8, 145, 178, 0.12);
+  --md-accent-fg-color--transparent: rgba(11, 130, 147, 0.12);
   --md-accent-bg-color: var(--oe-navy);
   --md-default-bg-color: var(--oe-paper);
   --md-default-fg-color: var(--oe-text);
   --md-default-fg-color--light: var(--oe-muted);
-  --md-default-fg-color--lighter: #91a2ae;
+  --md-default-fg-color--lighter: #9290a0;
   --md-default-fg-color--lightest: var(--oe-line);
   --md-typeset-color: var(--oe-text);
   --md-typeset-a-color: var(--oe-cyan);
   --md-code-fg-color: var(--oe-navy);
   --md-code-bg-color: var(--oe-paper-deep);
   --md-footer-bg-color: var(--oe-navy);
-  --md-footer-bg-color--dark: #080f1e;
-  --md-footer-fg-color: #d8e5ec;
-  --md-footer-fg-color--light: #a9bac5;
-  --md-footer-fg-color--lighter: #8396a4;
+  --md-footer-bg-color--dark: #141643;
+  --md-footer-fg-color: #f6f3ec;
+  --md-footer-fg-color--light: #d5d1c9;
+  --md-footer-fg-color--lighter: #aaa7b3;
 }
 
 html {
   background-color: var(--oe-paper) !important;
   background-image:
-    linear-gradient(rgba(15, 23, 42, 0.045) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(15, 23, 42, 0.045) 1px, transparent 1px),
-    linear-gradient(rgba(8, 145, 178, 0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(8, 145, 178, 0.025) 1px, transparent 1px);
-  background-size: 32px 32px, 32px 32px, 8px 8px, 8px 8px;
+    linear-gradient(rgba(30, 33, 96, 0.075) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(30, 33, 96, 0.075) 1px, transparent 1px),
+    linear-gradient(rgba(30, 33, 96, 0.026) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(30, 33, 96, 0.026) 1px, transparent 1px);
+  background-size: 40px 40px, 40px 40px, 8px 8px, 8px 8px;
   background-attachment: fixed;
 }
 
@@ -80,11 +80,11 @@ body,
 .md-header,
 .md-header[data-md-state="shadow"] {
   color: var(--oe-navy) !important;
-  background: rgba(247, 249, 248, 0.94) !important;
-  border-bottom: 1px solid var(--oe-line);
-  box-shadow: 0 6px 22px rgba(15, 23, 42, 0.05) !important;
-  backdrop-filter: blur(18px) saturate(125%);
-  -webkit-backdrop-filter: blur(18px) saturate(125%);
+  background: rgba(246, 243, 236, 0.97) !important;
+  border-bottom: 2px solid var(--oe-navy);
+  box-shadow: none !important;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .md-header__title,
@@ -102,7 +102,7 @@ body,
 }
 
 .md-search__form {
-  background: rgba(255, 255, 255, 0.88) !important;
+  background: var(--oe-surface) !important;
   border: 1px solid var(--oe-line-strong);
   border-radius: var(--oe-radius-small);
   box-shadow: none;
@@ -116,8 +116,8 @@ body,
 
 .md-tabs {
   color: var(--oe-text) !important;
-  background: rgba(247, 249, 248, 0.9) !important;
-  border-bottom: 1px solid var(--oe-line);
+  background: rgba(246, 243, 236, 0.96) !important;
+  border-bottom: 1px solid var(--oe-line-strong);
 }
 
 .md-tabs__link {
@@ -194,9 +194,9 @@ body,
 
 /* Code and terminal evidence */
 .md-typeset code {
-  color: #0e7490;
+  color: var(--oe-cyan);
   background: var(--oe-cyan-soft);
-  border: 1px solid rgba(8, 145, 178, 0.24);
+  border: 1px solid rgba(11, 130, 147, 0.24);
   border-radius: var(--oe-radius-small);
   padding: 0.08rem 0.28rem;
 }
@@ -216,13 +216,13 @@ body,
 .md-typeset .prompt-box {
   color: #d8f7ff !important;
   background: var(--oe-navy) !important;
-  border: 1px solid #29415a;
+  border: 1px solid #373a78;
   border-radius: var(--oe-radius-card);
 }
 
 .md-typeset pre,
 .md-typeset .highlight pre {
-  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--oe-shadow-sm);
 }
 
 .md-typeset pre code { border: 0; }
@@ -232,20 +232,19 @@ body,
 /* Buttons */
 .md-typeset .md-button {
   color: var(--oe-navy) !important;
-  background: rgba(255, 255, 255, 0.72) !important;
+  background: var(--oe-surface) !important;
   border: 1px solid var(--oe-line-strong) !important;
   border-radius: var(--oe-radius-small) !important;
   box-shadow: var(--oe-shadow-sm);
   font-weight: 700;
   padding: 0.58rem 1.15rem;
-  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
 }
 
 .md-typeset .md-button:hover {
   background: var(--oe-surface) !important;
   border-color: var(--oe-cyan) !important;
   box-shadow: var(--oe-shadow-cyan);
-  transform: translateY(-2px);
 }
 
 .md-typeset .md-button--primary {
@@ -267,14 +266,15 @@ body,
   isolation: isolate;
   overflow: hidden;
   margin: -1.5rem -0.8rem 3.5rem;
-  padding: 4.5rem clamp(1.5rem, 5vw, 4.5rem) 3.5rem;
+  padding: 3.8rem clamp(1.5rem, 5vw, 4.5rem) 3.2rem;
   color: var(--oe-text);
   text-align: left;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.84) 64%, rgba(224, 247, 255, 0.72) 100%);
-  border: 1px solid var(--oe-line-strong);
-  border-top: 4px solid var(--oe-cyan-bright);
-  border-radius: var(--oe-radius-card);
-  box-shadow: var(--oe-shadow-md);
+  background: rgba(246, 243, 236, 0.72);
+  border: 0;
+  border-top: 2px solid var(--oe-navy);
+  border-bottom: 1px solid var(--oe-line-strong);
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .hero::before {
@@ -283,36 +283,28 @@ body,
   inset: 0;
   z-index: -2;
   pointer-events: none;
-  background-image:
-    linear-gradient(rgba(15, 23, 42, 0.055) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(15, 23, 42, 0.055) 1px, transparent 1px);
-  background-size: 28px 28px;
-  mask-image: linear-gradient(90deg, #000 0%, rgba(0, 0, 0, 0.68) 72%, transparent 100%);
-  -webkit-mask-image: linear-gradient(90deg, #000 0%, rgba(0, 0, 0, 0.68) 72%, transparent 100%);
+  background: none;
 }
 
 .hero::after {
   content: "ARCH → SPEC → BUILD → REVIEW";
   position: absolute;
-  right: -2.2rem;
-  top: 7rem;
+  right: 1.25rem;
+  top: 8.5rem;
   z-index: -1;
   width: 17rem;
-  padding: 1.15rem 1.2rem;
-  color: var(--oe-cyan);
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(8, 145, 178, 0.38);
-  border-left: 4px solid var(--oe-cyan-bright);
-  box-shadow:
-    0 58px 0 -1px rgba(255, 255, 255, 0.6),
-    0 58px 0 0 rgba(8, 145, 178, 0.24),
-    0 116px 0 -1px rgba(255, 255, 255, 0.48),
-    0 116px 0 0 rgba(217, 70, 239, 0.2);
+  padding: 0.5rem 0 0.5rem 1rem;
+  color: var(--oe-navy);
+  background: transparent;
+  border: 0;
+  border-left: 2px solid var(--oe-cyan-bright);
+  box-shadow: none;
   font-family: "JetBrains Mono", "Cascadia Code", monospace;
   font-size: 0.68rem;
   font-weight: 700;
+  line-height: 1.55;
   letter-spacing: 0.08em;
-  transform: rotate(-1deg);
+  transform: none;
 }
 
 .hero-banner {
@@ -323,10 +315,10 @@ body,
   margin-bottom: 1.4rem;
   padding: 0.42rem 0.55rem;
   color: var(--oe-text) !important;
-  background: rgba(255, 255, 255, 0.88);
+  background: transparent;
   border: 1px solid var(--oe-line);
   border-radius: var(--oe-radius-small);
-  box-shadow: var(--oe-shadow-sm);
+  box-shadow: none;
   font-family: "JetBrains Mono", "Cascadia Code", monospace;
   font-size: 0.76rem;
   text-decoration: none !important;
@@ -341,7 +333,7 @@ body,
   padding: 0.14rem 0.5rem;
   color: var(--oe-magenta-deep);
   background: var(--oe-magenta-soft);
-  border: 1px solid rgba(217, 70, 239, 0.38);
+  border: 1px solid rgba(199, 47, 131, 0.38);
   border-radius: var(--oe-radius-small);
   font-size: 0.62rem;
   font-weight: 800;
@@ -402,6 +394,7 @@ body,
   display: inline-block;
   margin: 0 0 1.15rem 1rem;
   color: var(--oe-magenta-deep);
+  font-family: "Segoe Print", "Bradley Hand", "Comic Sans MS", cursive;
   font-size: 1rem;
   font-style: italic;
   font-weight: 650;
@@ -453,13 +446,13 @@ body,
   gap: 0.25rem;
   padding: 0.34rem 0.68rem;
   color: var(--oe-text);
-  background: rgba(255, 255, 255, 0.84);
+  background: var(--oe-surface);
   border: 1px solid var(--oe-line-strong);
   border-radius: var(--oe-radius-small);
   font-family: "JetBrains Mono", "Cascadia Code", monospace;
   font-size: 0.68rem;
   font-weight: 600;
-  box-shadow: var(--oe-shadow-sm);
+  box-shadow: none;
 }
 
 .hero-pills .pill b {
@@ -468,15 +461,15 @@ body,
 }
 
 .hero-pills .pill--accent {
-  color: #0e6277;
+  color: #0b6e7a;
   background: var(--oe-cyan-soft);
-  border-color: rgba(8, 145, 178, 0.38);
+  border-color: rgba(11, 130, 147, 0.38);
 }
 
 .hero-pills .pill--version {
   color: var(--oe-magenta-deep);
   background: var(--oe-magenta-soft);
-  border-color: rgba(217, 70, 239, 0.34);
+  border-color: rgba(199, 47, 131, 0.34);
 }
 
 .hero-pills .pill--version b { color: var(--oe-magenta-deep); }
@@ -529,11 +522,13 @@ body,
   margin: 1.5rem 0;
   padding: 1.15rem 1.35rem;
   color: var(--oe-text);
-  background: linear-gradient(90deg, rgba(224, 247, 255, 0.72), rgba(255, 255, 255, 0.9));
-  border: 1px solid var(--oe-line);
-  border-left: 4px solid var(--oe-cyan-bright);
-  border-radius: var(--oe-radius-card);
-  box-shadow: var(--oe-shadow-sm);
+  background: rgba(246, 243, 236, 0.72);
+  border: 0;
+  border-top: 1px solid var(--oe-line-strong);
+  border-bottom: 1px solid var(--oe-line-strong);
+  border-left: 3px solid var(--oe-cyan-bright);
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .note-panel { border-left-color: var(--oe-magenta); }
@@ -567,13 +562,13 @@ body,
 .two-col-visual {
   padding: 1.2rem;
   background:
-    linear-gradient(rgba(15, 23, 42, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(15, 23, 42, 0.035) 1px, transparent 1px),
-    rgba(255, 255, 255, 0.82);
+    linear-gradient(rgba(30, 33, 96, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(30, 33, 96, 0.055) 1px, transparent 1px),
+    rgba(246, 243, 236, 0.78);
   background-size: 20px 20px;
   border: 1px solid var(--oe-line-strong);
   border-radius: var(--oe-radius-card);
-  box-shadow: var(--oe-shadow-sm);
+  box-shadow: none;
 }
 
 .two-col-visual img { border-radius: var(--oe-radius-small); }
@@ -585,11 +580,11 @@ body,
 .resource-card,
 .collab-card,
 .timeline-item {
-  background: rgba(255, 255, 255, 0.88) !important;
+  background: rgba(251, 248, 241, 0.78) !important;
   border: 1px solid var(--oe-line) !important;
   border-radius: var(--oe-radius-card) !important;
-  box-shadow: var(--oe-shadow-sm);
-  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+  box-shadow: none;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
 }
 
 .md-typeset .grid.cards > ul > li:hover,
@@ -598,8 +593,7 @@ body,
 .collab-card:hover,
 .timeline-item:hover {
   border-color: var(--oe-cyan) !important;
-  box-shadow: var(--oe-shadow-md);
-  transform: translateY(-3px);
+  box-shadow: 3px 3px 0 rgba(34, 204, 224, 0.16);
 }
 
 .resource-grid {
@@ -625,7 +619,7 @@ body,
   position: absolute;
   inset: 0 0 auto;
   height: 3px;
-  background: linear-gradient(90deg, var(--oe-cyan-bright), var(--oe-magenta));
+  background: var(--oe-cyan-bright);
   transform: scaleX(0.22);
   transform-origin: left;
   transition: transform 0.24s ease;
@@ -641,7 +635,7 @@ body,
   padding: 0.24rem 0.5rem;
   color: var(--oe-cyan);
   background: var(--oe-cyan-soft);
-  border: 1px solid rgba(8, 145, 178, 0.28);
+  border: 1px solid rgba(11, 130, 147, 0.28);
   border-radius: var(--oe-radius-small);
   font-family: "JetBrains Mono", "Cascadia Code", monospace;
   font-size: 0.64rem;
@@ -718,7 +712,7 @@ body,
 .timeline-item--upcoming .timeline-date {
   color: var(--oe-magenta-deep);
   background: var(--oe-magenta-soft);
-  border-color: rgba(217, 70, 239, 0.3);
+  border-color: rgba(199, 47, 131, 0.3);
 }
 
 .timeline-kind {
@@ -770,10 +764,10 @@ body,
 /* Tables and admonitions */
 .md-typeset table:not([class]) {
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(251, 248, 241, 0.86);
   border: 1px solid var(--oe-line);
   border-radius: var(--oe-radius-card);
-  box-shadow: var(--oe-shadow-sm);
+  box-shadow: none;
 }
 
 .md-typeset table:not([class]) th {
@@ -790,11 +784,11 @@ body,
 
 .md-typeset .admonition,
 .md-typeset details {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(251, 248, 241, 0.86);
   border: 1px solid var(--oe-line);
   border-left: 4px solid var(--oe-cyan-bright);
   border-radius: var(--oe-radius-card);
-  box-shadow: var(--oe-shadow-sm);
+  box-shadow: none;
 }
 
 .md-typeset .admonition-title,
@@ -839,14 +833,14 @@ body,
 
 .md-typeset .tabbed-content {
   padding: 1rem 1.2rem;
-  background: rgba(255, 255, 255, 0.88);
+  background: rgba(251, 248, 241, 0.82);
   border: 1px solid var(--oe-line);
   border-radius: var(--oe-radius-card);
 }
 
 .diagram-container {
   padding: 1.2rem;
-  background: rgba(255, 255, 255, 0.86);
+  background: rgba(251, 248, 241, 0.82);
   border: 1px solid var(--oe-line);
   border-radius: var(--oe-radius-card);
 }
@@ -890,10 +884,10 @@ body,
   overflow: hidden;
   margin: 4rem -0.8rem 1.5rem;
   padding: 3.75rem 1.5rem;
-  color: #d8e5ec;
+  color: var(--oe-paper);
   text-align: center;
   background: var(--oe-navy);
-  border: 1px solid #29415a;
+  border: 1px solid #373a78;
   border-top: 4px solid var(--oe-cyan-bright);
   border-radius: var(--oe-radius-card);
   box-shadow: var(--oe-shadow-md);
@@ -923,8 +917,8 @@ body,
 
 .footer-cta .md-button:not(.md-button--primary) {
   color: #e5f4fa !important;
-  background: rgba(255, 255, 255, 0.06) !important;
-  border-color: #587287 !important;
+  background: rgba(246, 243, 236, 0.06) !important;
+  border-color: #7778a2 !important;
 }
 
 .status-footer {
@@ -938,24 +932,24 @@ body,
 }
 
 .status-footer code {
-  color: #0e6277 !important;
+  color: #0b6e7a !important;
   background: var(--oe-cyan-soft) !important;
-  border-color: rgba(8, 145, 178, 0.3);
+  border-color: rgba(11, 130, 147, 0.3);
   font-size: 0.7rem;
   font-weight: 700;
 }
 
 .md-footer,
 .md-footer-meta {
-  color: #d8e5ec !important;
+  color: var(--oe-paper) !important;
   background: var(--oe-navy) !important;
-  border-top: 1px solid #29415a;
+  border-top: 1px solid #373a78;
 }
 
 .md-footer__link,
 .md-footer-meta__inner,
 .md-footer-meta__inner a,
-.md-footer-copyright { color: #a9bac5 !important; }
+.md-footer-copyright { color: #d5d1c9 !important; }
 
 /* Responsive polish */
 @media (max-width: 60em) {


### PR DESCRIPTION
## Summary

Moves the ALDC documentation from a cool, glassy landing-page treatment toward the warmer engineering-notebook identity used by the ALDC-GRAPH story.

### Visual changes

- Warm paper canvas: `#F6F3EC`
- Ink navy: `#1E2160`
- Technical cyan: `#22CCE0`
- Human-judgment magenta: `#C72F83`
- More visible major/minor notebook grid
- Flat header and navigation with stronger ink rules
- Hero changed from a cyan glass gradient to an open paper composition
- Side flow rendered as a notebook annotation
- Squarer cards, panels and diagrams with substantially reduced shadows
- Handwritten-style treatment reserved for the human annotation
- Logo, favicon and brand banner aligned with the same palette

### Validation

- SVG assets parse as valid XML.
- `npm test`: 0 errors.
- `python -m mkdocs build --clean`: successful.
- Existing documentation warnings are unchanged and unrelated.

### Review note

The local build is verified, but the cloud browser in this session could not open the loopback preview. The PR intentionally isolates the visual layer so it can be reviewed safely before merge.
