### PR TITLE
Github Copilot plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "aldc-marketplace",
+  "owner": {
+    "name": "javiarmesto",
+    "url": "https://github.com/javiarmesto"
+  },
+  "metadata": {
+    "description": "ALDC — AI-Native AL Development Collection for Microsoft Dynamics 365 Business Central. Agents, skills, workflows, and coding standards for extension-only development."
+  },
+  "plugins": [
+    {
+      "name": "aldc",
+      "source": "./claude-plugin",
+      "description": "AL agents (incl. on-demand triage + dredd audit) + TDD subagents, skills, and workflows for BC extension development with TDD, BCQuality-cited review, event-driven architecture, and HITL gates.",
+      "version": "4.2.0"
+    }
+  ]
+}

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "aldc",
-      "source": "./claude-plugin",
+      "source": ".",
       "description": "AL agents (incl. on-demand triage + dredd audit) + TDD subagents, skills, and workflows for BC extension development with TDD, BCQuality-cited review, event-driven architecture, and HITL gates.",
       "version": "4.2.0"
     }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Then, from the Command Palette:
 - `AL Collection: Update Toolkit` — merges a new version, preserving your customizations
 - `AL Collection: Validate Installation` — verifies compliance
 
+### GitHub Copilot (Plugin Marketplace)
+
+ALDC also ships as an installable Copilot plugin — `plugin.json` declares the agents (`agents/`), skills (`skills/`), and prompts (`prompts/`) that get installed, for editors that support the Copilot plugin marketplace:
+
+```bash
+copilot plugin marketplace add javiarmesto/ALDC-AL-Development-Collection
+copilot plugin install aldc@aldc-marketplace
+```
+
+The agents, skills, and prompts are installed under your Copilot plugins folder and become available immediately, no `.github/` copy step required.
+
 ### Claude Code (Plugin)
 
 ```bash

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,58 @@
+{
+  "name": "aldc",
+  "version": "4.2.0",
+  "description": "AI-Native AL Development Collection for Microsoft Dynamics 365 Business Central. Agents (architect, developer, conductor, pre-sales, agent-builder, triage, dredd) + TDD subagents, skills, and workflows for extension-only development with TDD, BCQuality-cited review/audit, event-driven architecture, and HITL gates.",
+  "author": {
+    "name": "javiarmesto",
+    "url": "https://github.com/javiarmesto"
+  },
+  "homepage": "https://github.com/javiarmesto/ALDC-AL-Development-Collection",
+  "repository": "https://github.com/javiarmesto/ALDC-AL-Development-Collection",
+  "license": "MIT",
+  "keywords": [
+    "AL",
+    "Business Central",
+    "Dynamics 365",
+    "ERP",
+    "extension-development",
+    "TDD",
+    "event-driven",
+    "Microsoft",
+    "architecture",
+    "testing",
+    "API",
+    "debugging"
+  ],
+  "agents" : "agents/",
+  "skills" : "skills/",
+  "commands" : "prompts/",
+  "mcpServers": {
+    "al-symbols-mcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@nicholasglazer/al-symbols-mcp"]
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "microsoft-docs": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    }
+  },
+  "userConfig": {
+    "bcSandboxUrl": {
+      "type": "string",
+      "title": "BC Sandbox URL",
+      "description": "URL of your Business Central sandbox environment (e.g., https://businesscentral.dynamics.com/your-tenant)",
+      "sensitive": false
+    },
+    "publisherName": {
+      "type": "string",
+      "title": "Publisher Name",
+      "description": "Your extension publisher name for app.json",
+      "sensitive": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a root-level `plugin.json` and `.github/plugin/marketplace.json` so ALDC can be installed as a GitHub Copilot plugin, and documents the install commands in the README.

## Changes

- **`plugin.json`** (new) — plugin manifest declaring `agents/`, `skills/`, `prompts/`, MCP servers (`al-symbols-mcp`, `context7`, `microsoft-docs`), and `userConfig` (`bcSandboxUrl`, `publisherName`)
- **`.github/plugin/marketplace.json`** (new) — marketplace registry (`aldc-marketplace`) listing the `aldc` plugin with `source: "."`
- **`README.md`** — new "GitHub Copilot (Plugin Marketplace)" section with:
  ```bash
  copilot plugin marketplace add javiarmesto/ALDC-AL-Development-Collection
  copilot plugin install aldc@aldc-marketplace
  ```

Please verify this as you would - I haven't had much time to test!